### PR TITLE
upgrade test scripts to Python 3

### DIFF
--- a/ats/test/HelloATS/ats_check_log.py
+++ b/ats/test/HelloATS/ats_check_log.py
@@ -1,26 +1,25 @@
-#!/usr/apps/ats/7.0.1/bin/python
+#!/usr/bin/env python3
 import os
 import sys
 
 if __name__ == '__main__':
-    if len(sys.argv) < 2:
+    if len(sys.argv) != 2:
         sys.exit(1)
 
-    logfile = sys.argv[1]
+    LOGFILE = sys.argv[1]
 
-    if os.path.exists(logfile):
-        with open(logfile, 'r') as f:
-            lines = f.readlines()
+    if os.path.exists(LOGFILE):
+        with open(LOGFILE, 'r') as f:
+            LOGFILE_CONTENTS = f.read()
 
-        for line in lines:
-            if "SUCCESS" in line:
-                print "checker success"
-                sys.exit(0)
-            elif "FAILURE" in line:
-                print "checker failed"
-                sys.exit(-1)
+        if "SUCCESS" in LOGFILE_CONTENTS:
+            print("checker success")
+            sys.exit(0)
+        elif "FAILURE" in LOGFILE_CONTENTS:
+            print("checker failed")
+            sys.exit(-1)
 
     # If we get to here, we did not find the log file
-    # or the log file did not have PASSED in it
-    print "test did not pass"
+    # or the log file did not have SUCCESS in it
+    print("test did not pass")
     sys.exit(1)

--- a/ats/test/HelloATS/create_test_ats.py
+++ b/ats/test/HelloATS/create_test_ats.py
@@ -1,7 +1,8 @@
-#!/usr/apps/ats/7.0.1/bin/python
+#!/usr/bin/env python3
 """Create a test.ats file."""
 import itertools
 import os
+import sys
 
 
 def get_file_header():
@@ -9,13 +10,13 @@ def get_file_header():
     ats_log_checker_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), 'ats_check_log.py')
     if not os.path.isfile(ats_log_checker_path):
-        exit(1)
+        sys.exit(1)
 
-    ofp_header = """import os
+    ofp_header = f"""import os
 glue(independent=True)
 glue(keep=True)
-my_checker = '%s'
-""" % ats_log_checker_path
+my_checker = '{ats_log_checker_path}'
+"""
     return ofp_header
 
 
@@ -52,4 +53,4 @@ if __name__ == "__main__":
             ofp.write(test)
             ofp.write(testif)
 
-    print "Most Excellent! Created ats test file %s\n" % TEST_ATS
+    print(f"Most Excellent! Created ats test file {TEST_ATS}\n")


### PR DESCRIPTION
Test scripts **ats_check_log.py** and **create_test_ats.py** in ats/test/HelloATS are simple enough to upgrade to Python 3 without effecting the user's workflow or any dependencies in other files.