### PR TITLE
return import statement to original location

### DIFF
--- a/ats/src/ats/executables.py
+++ b/ats/src/ats/executables.py
@@ -1,10 +1,11 @@
 from atsut import is_valid_executable
-from configuration import machine
 
 class Executable(object):
     """Information about an executable to use. Can be created from string or
      list of strings."""
     def __init__ (self, value):
+        # NOTE: import done at __init__ to workaround circular dependency.
+        from configuration import machine
         if isinstance(value, (str, unicode)):
             self.commandList = machine.split(value)
         else:


### PR DESCRIPTION
During my earlier updates I moved an import statement from an __init__ call to the top of the module. This should have been left alone as the odd location of the import was intentional. Returning the import to the __init__ call is needed, as it is a workaround for a circular dependency. This should eventually be addressed.