### PR TITLE
default "machine" is missing numNodes

### DIFF
--- a/ats/src/ats/machines.py
+++ b/ats/src/ats/machines.py
@@ -780,6 +780,7 @@ is hard upper limit.
         self.numberTestsRunning = 0
         self.numberNodesExclusivelyUsed = 0
         self.numberTestsRunningMax = max(1, abs(npMaxH))
+        self.numNodes = -1
         self.npMaxH= npMaxH    # allow the machine modules to access this value
         self.hardLimit = (npMaxH > 0)
         self.naptime = 0.2 #number of seconds to sleep between checks on running tests.


### PR DESCRIPTION
numNodes is being set in most of the modules in the "atsMachines" directory but is also referenced in some cases before anything from that directory is encountered.