### PR TITLE
safe updates applied from 2to3 upgrade tool

### DIFF
--- a/ats/docs/source/conf.py
+++ b/ats/docs/source/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'ATS'
-copyright = u'2011, Lawrence Livermore National Security LLC'
+project = 'ATS'
+copyright = '2011, Lawrence Livermore National Security LLC'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -178,8 +178,8 @@ htmlhelp_basename = 'ATSdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'ATS.tex', u'ATS Documentation',
-   u'Paul F. Dubois and Nu Ai Tang', 'manual'),
+  ('index', 'ATS.tex', 'ATS Documentation',
+   'Paul F. Dubois and Nu Ai Tang', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -211,6 +211,6 @@ latex_domain_indices = False
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'ats', u'ATS Documentation',
-     [u'Paul F. Dubois and Nu Ai Tang'], 1)
+    ('index', 'ats', 'ATS Documentation',
+     ['Paul F. Dubois and Nu Ai Tang'], 1)
 ]

--- a/ats/src/ats/__init__.py
+++ b/ats/src/ats/__init__.py
@@ -52,5 +52,5 @@ from log import log, terminal
 from times import Duration
 # make statuses available as their abbreviations, too.
 for key, value in statuses.items():
-    exec "%s = %s" % (value.abr, key)
+    exec("%s = %s" % (value.abr, key))
 del key, value

--- a/ats/src/ats/atsut.py
+++ b/ats/src/ats/atsut.py
@@ -29,7 +29,7 @@ class _StatusCode:
     def __eq__(self, other):
         if isinstance(other, _StatusCode):
             return self.name == other.name
-        elif isinstance(other, (str, unicode)):
+        elif isinstance(other, str):
             return self.name == other or self.abr == other
         else:
             return False

--- a/ats/src/ats/attributedict.py
+++ b/ats/src/ats/attributedict.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from cStringIO import StringIO
+from io import StringIO
 
 class AttributeDict (dict):
     """A dictionary whose items can be accessed as attributes. Be careful not to
@@ -17,7 +17,7 @@ class AttributeDict (dict):
         try:
             return self[name]
         except KeyError:
-            raise AttributeError, "No attribute %s" % name
+            raise AttributeError("No attribute %s" % name)
 
     def __setattr__(self, name, value):
         "Convert an attribute set into a key set."
@@ -28,7 +28,7 @@ class AttributeDict (dict):
         try:
             del self[name]
         except KeyError:
-            raise AttributeError, 'No attribute %s' % name
+            raise AttributeError('No attribute %s' % name)
 
     def __repr__(self):
         out = StringIO()

--- a/ats/src/ats/configuration.py
+++ b/ats/src/ats/configuration.py
@@ -532,7 +532,7 @@ def init(clas = '', adder = None, examiner=None):
     defaultExecutable = executables.Executable(abspath(options.executable))
     # ATSROOT is used in tests.py to allow paths pointed at the executable's directory
     commandList = machine.split(repr(defaultExecutable))
-    if os.environ.has_key('ATSROOT'):
+    if 'ATSROOT' in os.environ:
         ATSROOT = os.environ['ATSROOT']
     else:
         ATSROOT = os.path.dirname(defaultExecutable.path)

--- a/ats/src/ats/executables.py
+++ b/ats/src/ats/executables.py
@@ -6,7 +6,7 @@ class Executable(object):
     def __init__ (self, value):
         # NOTE: import done at __init__ to workaround circular dependency.
         from configuration import machine
-        if isinstance(value, (str, unicode)):
+        if isinstance(value, str):
             self.commandList = machine.split(value)
         else:
             self.commandList = value[:]

--- a/ats/src/ats/log.py
+++ b/ats/src/ats/log.py
@@ -127,7 +127,7 @@ class AtsLog (object):
         except Exception:
             print >>sys.stderr, msg
             print(msg, file=sys.stderr)
-        raise SystemExit, 1
+        raise SystemExit(1)
 
 log = AtsLog(name="ats.log")
 terminal = AtsLog(echo=True, logging=False)

--- a/ats/src/ats/machines.py
+++ b/ats/src/ats/machines.py
@@ -87,7 +87,7 @@ class MachineCore(object):
             else:   # test has finished
                 if test.status is not PASSED:
                     if configuration.options.oneFailure:
-                        raise AtsError, "Test failed in oneFailure mode."
+                        raise AtsError("Test failed in oneFailure mode.")
         self.running = stillRunning
 
     def remainingCapacity(self):
@@ -360,7 +360,7 @@ call noteEnd for machine-specific part.
                 os.environ['OMP_NUM_THREADS'] = str(omp_num_threads)
             else:
                 # Priority 3 setting, the user has already set OMP_NUM_THREADS in their environment
-                if os.environ.has_key('OMP_NUM_THREADS'):
+                if 'OMP_NUM_THREADS' in os.environ:
                     if configuration.options.verbose:
                         temp_omp= os.getenv("OMP_NUM_THREADS")
                         # print "ATS detected that OMP_NUM_THREADS is already set to %s" % (temp_omp)
@@ -644,7 +644,7 @@ The subprocess part of launch. Also the part that might fail.
 
             return True
 
-        except OSError, e:
+        except OSError as e:
             if test.stdOutLocGet() != 'terminal':
                 test.fileHandleClose()
 
@@ -693,7 +693,7 @@ The subprocess part of launch. Also the part that might fail.
         else:
             if exit:
                 log('%s FATAL RETURN CODE %d Command: %s' % ("ATS", exitCode, cmd_line), echo=True)
-                raise SystemExit, 1
+                raise SystemExit(1)
 
         return exitCode
 
@@ -746,7 +746,7 @@ The subprocess part of launch. Also the part that might fail.
         else:
             if exit:
                 log('%s FATAL RETURN CODE %d Command: %s' % ("ATS", exitCode, cmd_line), echo=True)
-                raise SystemExit, 1
+                raise SystemExit(1)
 
         return exitCode
 

--- a/ats/src/ats/management.py
+++ b/ats/src/ats/management.py
@@ -53,7 +53,7 @@ Attributes:
 
     def restart(self):
         "Reinitialize basic data structures."
-        self.started = datestamp(long=1)
+        self.started = datestamp(long_format=True)
         self.collectTimeEnded = self.started
         self.filters = []
         self.testlist = []
@@ -80,13 +80,13 @@ Attributes:
             try:
                 f = str(f)
             except Exception:
-                raise AtsError, "filter must be convertible to string"
+                raise AtsError("filter must be convertible to string")
             if not f:
                 continue
             try:
                 r = eval(f, {}, {})
             except SyntaxError:
-                raise AtsError, 'Mal-formed filter, %s' % repr(f)
+                raise AtsError('Mal-formed filter, %s' % repr(f))
             except KeyboardInterrupt:
                 raise
             except Exception:
@@ -98,7 +98,7 @@ Attributes:
         """Compute the environment in which filters for test will be
             evaluated."""
         if not isinstance(test, AtsTest):
-            raise AtsError, 'filterenv argument must be a test instance.'
+            raise AtsError('filterenv argument must be a test instance.')
         fe = {}
         for f in _filterwith:
             exec(f, fe)
@@ -127,7 +127,7 @@ Attributes:
                     return f
             except KeyboardInterrupt:
                 raise
-            except Exception, e:
+            except Exception as e:
                 if debug():
                     log('In filter %s:'% repr(f), e)
                 return f
@@ -158,17 +158,16 @@ Attributes:
     def undefine(*args):
         "Remove one or more symbols for input files."
         for x in args:
-            if testEnvironment.has_key(x):
+            if x in testEnvironment:
                 del testEnvironment[x]
 
     def get(self, name):
         """Return the definition of name from the test environment.
         """
-        if testEnvironment.has_key(name):
+        if name in testEnvironment:
             return testEnvironment.get(name)
 
-        raise AtsError, \
-            "Could not find name %s in vocabulary." % name
+        raise AtsError("Could not find name %s in vocabulary." % name)
 
     alreadysourced = []
 
@@ -204,12 +203,12 @@ Attributes:
             try:
                 f = open(t1)
                 break
-            except IOError, e:
+            except IOError as e:
                 pass
         else:
             log("Error opening input file:", t1, echo=True)
             self.badlist.append(t1)
-            raise AtsError, "Could not open input file %s" % path
+            raise AtsError("Could not open input file %s" % path)
         t = abspath(t1)
         directory, filename = os.path.split(t1)
         name, e = os.path.splitext(filename)
@@ -297,7 +296,7 @@ Attributes:
         if self.testlist:
             log("""
 =========================================================
-ATS RESULTS %s""" % datestamp(long=1), echo = True)
+ATS RESULTS %s""" % datestamp(long_format=True), echo=True)
             log('-------------------------------------------------',
                 echo = True)
             self.report()
@@ -305,7 +304,7 @@ ATS RESULTS %s""" % datestamp(long=1), echo = True)
                 echo = True)
         if not configuration.options.skip:
             log("""
-ATS SUMMARY %s""" % datestamp(long=1), echo = True)
+ATS SUMMARY %s""" % datestamp(long_format=True), echo=True)
             self.summary(log)
             self._summary2(log)
 
@@ -315,7 +314,7 @@ ATS SUMMARY %s""" % datestamp(long=1), echo = True)
         log.echo = True
         log("ATS WALL TIME", wallTime())
         log("ATS COLLECTION END", self.collectTimeEnded)
-        log('ATS END', datestamp(long=1))
+        log('ATS END', datestamp(long_format=True))
         log('ATS MACHINE TYPE', configuration.MACHINE_TYPE)
         if configuration.batchmachine is not None:
             log('ATS BATCH TYPE', configuration.BATCH_TYPE)
@@ -547,7 +546,7 @@ See manual for discussion of these arguments.
 
             # 2019-06-28 Sad added filter on the number of nodes requested for the test vs allocated for testing
 
-            if testobj.options.has_key('nn'):
+            if 'nn' in testobj.options:
                 my_nn = testobj.options.get('nn')
             else:
                 my_nn = -1
@@ -669,7 +668,7 @@ We immediately make sure each input file exists and is readable.
                             configuration.options.allInteractive)):
             for t in batchTests:
                 log( t, "BATCH sorting error.", echo=True)
-            raise ValueError, 'batch test(s) should not exist'
+            raise ValueError('batch test(s) should not exist')
 
         return interactiveTests, batchTests
 
@@ -741,7 +740,7 @@ to allow user a chance to add options and examine results of option parsing.
             self.batchmachine = None
         self.verbose = configuration.options.verbose or debug()
         log.echo = self.verbose
-        self.started = datestamp(long=1)
+        self.started = datestamp(long_format=True)
         self.continuationFileName = ''
         self.atsRunPath = os.getcwd()
         for a in configuration.options.filter:
@@ -810,14 +809,14 @@ to allow user a chance to add options and examine results of option parsing.
             log("ATS error while collecting tests.", echo=True)
             log(traceback.format_exc(), echo=True)
             errorOccurred = True
-            self.collectTimeEnded = datestamp(long=1)
+            self.collectTimeEnded = datestamp(long_format=True)
 
         except KeyboardInterrupt:
             log("Keyboard interrupt while collecting tests, terminating.",
                 echo=True)
             errorOccurred = True
 
-        self.collectTimeEnded = datestamp(long=1)
+        self.collectTimeEnded = datestamp(long_format=True)
         if errorOccurred:
             return
 
@@ -1032,7 +1031,7 @@ BATCHED = ats.BATCHED
         r = AttributeDict(
             started = self.started,
             options = self.options,
-            savedTime = datestamp(long=1),
+            savedTime = datestamp(long_format=True),
             collectTimeEnded = self.collectTimeEnded,
             badlist = self.badlist,
             filters = self.filters,
@@ -1218,11 +1217,11 @@ def filterdefs (text=None):
             for f in _filterwith:
                 exec(f, d)
             exec(text, d)
-        except SyntaxError, e:
-            raise AtsError, e
+        except SyntaxError as e:
+            raise AtsError(e)
         except KeyboardInterrupt:
             raise
-        except Exception, e:
+        except Exception as e:
             pass
         if debug():
             log('filterdefs:')

--- a/ats/src/ats/reportutils.py
+++ b/ats/src/ats/reportutils.py
@@ -39,9 +39,9 @@ def getStateFromFile(atsrFile):
             return None
         # These attributes are not found in older (~2011) atsr.py files.
         # When loading the database from an archive, this was causing failures.
-        if d.has_key("logDirectory"):
+        if "logDirectory" in d:
             state['logDirectory'] = d['logDirectory'] # We want access to the run's logs, but they're not stored as part of the test object
-        if d.has_key("atsMachineName"):
+        if "atsMachineName" in d:
             state['atsMachineName'] = d['machineName']   # Not sure how useful this will be, but it's available.
     else:
         print("Path does not exist.  Can't get the state for: %s" % atsrFile)
@@ -171,6 +171,6 @@ def elapsedTime( test ):
     try:
         e = test.endTime
         s = test.startTime
-    except AttributeError, foo:
+    except AttributeError as foo:
         return (0)
     return (e-s)

--- a/ats/src/ats/tests.py
+++ b/ats/src/ats/tests.py
@@ -140,7 +140,7 @@ class AtsTest (object):
             self.options.update(AtsTest.stuck)
             self.options.update(AtsTest.grouped)
             self.options.update(options)
-        except Exception, e:
+        except Exception as e:
             self.set(INVALID, 'Bad options: ' + e)
             return
 
@@ -153,7 +153,7 @@ class AtsTest (object):
         outOpts = ['file', 'terminal', 'both']
         if not self.testStdout in outOpts:
             msg = 'Invalid setting for option testStdout: ' + self.testStdout
-            raise AtsError, msg
+            raise AtsError(msg)
 
 
         if configuration.options.allInteractive:
@@ -265,7 +265,7 @@ class AtsTest (object):
                 self.timelimit = configuration.timelimit
             else:
                 self.timelimit = Duration(tl)
-        except AtsError, msg:
+        except AtsError as msg:
             self.set(INVALID, msg)
             return
 
@@ -401,7 +401,7 @@ class AtsTest (object):
             e = self.endTime
             s = self.startTime
             elapsed = e-s
-        except AttributeError, foo:
+        except AttributeError as foo:
             elapsed = 0.0
 
         if elapsed < 60.0:
@@ -473,7 +473,8 @@ class AtsTest (object):
         "Remove the named sticky options. With no arg, remove all."
         if kw:
             for k in kw:
-                if cls.stuck.has_key(k): del cls.stuck[k]
+                if k in cls.stuck:
+                    del cls.stuck[k]
         else:
             cls.stuck.clear()
     unstick = classmethod(unstick)
@@ -489,7 +490,8 @@ class AtsTest (object):
         "Remove the named tacked options"
         if kw:
             for k in kw:
-                if cls.tacked.has_key(k): del cls.tacked[k]
+                if k in cls.tacked:
+                    del cls.tacked[k]
         else:
             cls.tacked.clear()
     untack = classmethod(untack)
@@ -505,7 +507,8 @@ class AtsTest (object):
         "Remove the named glued options"
         if kw:
             for k in kw:
-                if cls.glued.has_key(k): del cls.glued[k]
+                if k in cls.glued:
+                    del cls.glued[k]
         else:
             cls.glued.clear()
     unglue = classmethod(unglue)
@@ -516,7 +519,7 @@ class AtsTest (object):
         """
         if kw:
             for k in kw:
-                if cls.glued.has_key(k):
+                if k in cls.glued:
                     return cls.glued[k]
                 else:
                     return None
@@ -585,7 +588,7 @@ class AtsTest (object):
         if self.testStdout != 'terminal':
             try:
                 f = open(self.outname, 'r')
-            except IOError, e:
+            except IOError as e:
                 self.notes = ['Missing output file.']
                 log('Missing output file', self.outname, e)
                 return

--- a/ats/src/ats/times.py
+++ b/ats/src/ats/times.py
@@ -7,9 +7,9 @@ atsStartTime = time.strftime("%y%m%d%H%M%S",_localtime)
 atsStartTimeLong = time.strftime('%B %d, %Y %H:%M:%S', _localtime)
 
 
-def datestamp (long=0):
+def datestamp(long_format=False):
     "Return formatted date and time. Shorter version is just time."
-    if long:
+    if long_format:
         return time.strftime('%B %d, %Y %H:%M:%S')
     else:
         return time.strftime('%H:%M:%S')
@@ -144,5 +144,5 @@ def timeSpecToSec(spec):
                 s = int(sp)
 
         return (h*3600 + 60 * m + s)
-    except Exception, e:
-        raise AtsError, "Bad time specification: %s" % specIn
+    except Exception as e:
+        raise AtsError("Bad time specification: %s" % specIn)

--- a/ats/src/ats/util/base.py
+++ b/ats/src/ats/util/base.py
@@ -36,21 +36,19 @@ class NoNewFields(object):
         nameIter = iter(self._fieldNames)
         for value in args:
             try:
-                name = nameIter.next()
+                name = next(nameIter)
                 self.__setattr__(name, value)
             except StopIteration:
-                raise AttributeError, \
-                    'Too many positional args initialzing %s object.  Expected %s, but got %s.' %\
-                    (self.__class__, len(self._fieldNames), len(args))
+                raise AttributeError('Too many positional args initialzing %s object.  Expected %s, but got %s.' %\
+                    (self.__class__, len(self._fieldNames), len(args)))
 
     def __setKeywordFields(self, kwargs):
-        for name, value in kwargs.iteritems():
+        for name, value in kwargs.items():
             self.__setattr__(name, value)
 
     def __setattr__(self, name, value):
         if name not in self.__dict__:
-            raise AttributeError, \
-                'Field "%s" not found in "%s" object.' % (name, self.__class__)
+            raise AttributeError('Field "%s" not found in "%s" object.' % (name, self.__class__))
         else:
             object.__setattr__(self, name, value)
 

--- a/ats/src/ats/util/commands.py
+++ b/ats/src/ats/util/commands.py
@@ -7,7 +7,7 @@ __all__=('EFFORT_ONLY_OUTPUT_STREAM','Command')
 
 EFFORT_ONLY_OUTPUT_STREAM = 'This empty output stream is the output of an EffortOnly command.'
 
-class UsageError(StandardError):
+class UsageError(Exception):
     """The user requested something unreasonable.
 
     Usual issue: executable not found.
@@ -47,7 +47,7 @@ class CommandRunner(object):
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)
                 Output_Stream = p1.communicate()[0]
-            except OSError, e :
+            except OSError as e :
                 if e.errno==2:
                     message = 'Execution of command "%s" failed.  %s.' %\
                                         (args[0], e.strerror)
@@ -93,7 +93,7 @@ def demo_command():
         args = ['bogus_command', '/']
         try:
             command.issueCommand(args)
-        except UsageError, e:
+        except UsageError as e:
             logger.info('Caught expected exception:\n%s\n' % e)
 
         logger.info('Running first command found:\n' + '-'*80)
@@ -107,7 +107,7 @@ def demo_command():
         argList = ['/',]
         try:
             command.issueFirstCommand(commandList, argList)
-        except UsageError, e:
+        except UsageError as e:
             logger.info('Caught expected exception:\n%s\n' % e)
 
     logger.info ('Demo with normal output.\n' + '='*80 + '\n')

--- a/ats/src/ats/util/generic_utils.py
+++ b/ats/src/ats/util/generic_utils.py
@@ -48,10 +48,10 @@ def importName( moduleName, name, default_func=None, verbose=False ):
     try:
         my_mod = __import__( moduleName, globals(), locals(), [name] )
         func   =  vars(my_mod)[name]
-    except ImportError, value:
+    except ImportError as value:
         print("Import of function %s from %s failed: %s" % (name, moduleName, value))
-        raise StandardError
-    except KeyError, value:
+        raise Exception
+    except KeyError as value:
         print("KeyError during import of function %s from %s failed: %s" % (name, moduleName, value))
         pass
 
@@ -94,16 +94,16 @@ def runCommand( cmd_line, file_name=None, exit=True, verbose=False):
             stdout_pipe.close()
             stderr_pipe.close()
 
-    except CalledProcessError, error:
+    except CalledProcessError as error:
         log('Command failed: error code %d' % error.returncode, echo=True)
         log('Failed Command: %s' % cmd_line, echo=True)
         if exit:
-            raise SystemExit, 1
-    except OSError, error:
+            raise SystemExit(1)
+    except OSError as error:
         log('Command failed with OSError: traceback %s' % error.child_traceback, echo=True)
         log('Failed Command: %s' % cmd_line, echo=True)
         if exit:
-            raise SystemExit, 1
+            raise SystemExit(1)
 
     return ( stdout_txt, stderr_txt )
 
@@ -166,7 +166,7 @@ def execute(cmd_line, file_name=None, verbose=False):
 def listdirs(folder):
     try:
         dir_list = [d for d in os.listdir(folder) if os.path.isdir(os.path.join(folder, d))]
-    except OSError, error:
+    except OSError as error:
         log("WARNING - listdirs: %s" % error.strerror, echo=True)
         dir_list = []
     return dir_list
@@ -176,7 +176,7 @@ def listDatedDirs(folder):
         dir_list = [d for d in os.listdir(folder) \
                       if re.search('2[0-9][0-9][0-9]_[0-9][0-9]$', d) \
                       if os.path.isdir(os.path.join(folder, d))]
-    except OSError, error:
+    except OSError as error:
         log("WARNING - listDatedDirs: %s" % error.strerror, echo=True)
         dir_list = []
     return dir_list
@@ -184,7 +184,7 @@ def listDatedDirs(folder):
 def listfiles(folder):
     try:
         file_list = [d for d in os.listdir(folder) if os.path.isfile(os.path.join(folder, d))]
-    except OSError, error:
+    except OSError as error:
         log("WARNING - listfiles: %s" % error.strerror, echo=True)
         file_list = []
     return file_list
@@ -199,7 +199,7 @@ def copyFile(filename, srcdir, destdir, groupID):
         try:
             os.chown( destfile, -1, groupID)
             os.chmod( destfile, stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP | stat.S_IWGRP )
-        except OSError, error:
+        except OSError as error:
             log('WARNING - failed to set permissions on %s: %s' % ( destfile, error.strerror),
                 echo=True)
         return destfile
@@ -216,7 +216,7 @@ def copyAndRenameFile(filename, newfilename, srcdir, destdir, groupID):
         try:
             os.chown( destfile, -1, groupID)
             os.chmod( destfile, stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP | stat.S_IWGRP )
-        except OSError, error:
+        except OSError as error:
             log('WARNING - failed to set permissions on %s: %s' % ( destfile, error.strerror),
                 echo=True)
         return destfile
@@ -232,35 +232,35 @@ def makeDir( new_dir ):
         try:
             os.mkdir( new_dir )
 
-        except OSError, error:
+        except OSError as error:
             log('Error making %s: %s' %( new_dir, error.strerror), echo=True)
-            raise SystemExit, 1
+            raise SystemExit(1)
 
     elif not os.path.isdir(new_dir):
         log('ERROR: %s exists and is NOT a directory' % new_dir, echo=True)
-        raise SystemExit, 1
+        raise SystemExit(1)
 
 def makeSymLink( path, target ):
     if not os.path.exists(target):
         try:
             os.symlink( path, target )
 
-        except OSError, error:
+        except OSError as error:
             log('Error making link to %s: %s' %( target, error.strerror), echo=True)
-            raise SystemExit, 1
+            raise SystemExit(1)
 
     elif os.path.islink(target):
         try:
             os.unlink( target)
             os.symlink( path, target )
 
-        except OSError, error:
+        except OSError as error:
             log('Error making link to %s: %s' %( target, error.strerror), echo=True)
-            raise SystemExit, 1
+            raise SystemExit(1)
 
     else:
         log('ERROR: %s exists and is NOT a symlink' % target, echo=True)
-        raise SystemExit, 1
+        raise SystemExit(1)
 
 
 

--- a/ats/src/atsMachines/FutureMachines/flux_direct.py
+++ b/ats/src/atsMachines/FutureMachines/flux_direct.py
@@ -68,7 +68,7 @@ def update_test_status(json_response, arg, errnum):
         else:
             # it didn't run ok, don't check anything else
             if configuration.options.oneFailure:
-                raise AtsError, "Test failed in oneFailure mode."
+                raise AtsError("Test failed in oneFailure mode.")
         print("UPDATING TEST STATUS TO %s" % status, file=sys.stderr)
         test_to_update.set(status, test_to_update.elapsedTime())
         arg.noteEnd(test_to_update)
@@ -190,7 +190,7 @@ class FluxDirect (lcMachines.LCMachineCore):
         new_ld_library_path = "/opt/ibm/spectrum_mpi/lib/pami_port:/opt/ibm/spectrum_mpi/lib:/opt/ibm/spectrum_mpi/lib:/opt/mellanox/hcoll/lib"
         if os.environ['LD_LIBRARY_PATH']:
             new_ld_library_path += ":{}".format(os.environ['LD_LIBRARY_PATH'])
-        jobspec['environ'] = {k: v for k, v in jobspec['environ'].iteritems() if k.split('_')[0] not in ('JSM', 'OMPI', 'PMIX', 'ENVIRONMENT')}
+        jobspec['environ'] = {k: v for k, v in jobspec['environ'].items() if k.split('_')[0] not in ('JSM', 'OMPI', 'PMIX', 'ENVIRONMENT')}
         jobspec['environ'].update({"OMPI_MCA_osc": "pt2pt",
                                    "OMPI_MCA_pml": "yalla",
                                    "OMPI_MCA_btl": "self",

--- a/ats/src/atsMachines/lcBatch.py
+++ b/ats/src/atsMachines/lcBatch.py
@@ -260,7 +260,7 @@ def checkFile(file):
         msg = '%s does not exist or is not accessible'%file
         return -1, msg
 
-    if size == 0L:
+    if size == 0:
         msg = '%s has zero filesize'%file
         return 1, msg
     else:

--- a/ats/src/atsMachines/lcMachines.py
+++ b/ats/src/atsMachines/lcMachines.py
@@ -13,7 +13,7 @@ class LCMachineCore (machines.Machine):
     def kill(self, test):
         "Final cleanup if any."
 
-        for killTimes in xrange(0,1):
+        for killTimes in range(0,1):
 
             if self.lastSqueueResult is None or ( (time.time() - self.lastTimeSqueueCalled) > 60):   # in seconds
                 self.lastSqueueResult= utils.getAllSlurmStepIds()

--- a/ats/src/atsMachines/lsf_asq.py
+++ b/ats/src/atsMachines/lsf_asq.py
@@ -916,5 +916,5 @@ class lsfMachine (machines.Machine):
                     retcode= subprocess.call("bkill -J " + test.jobname, shell=True)
                     if retcode < 0:
                         log("---- bkill() in lsf_asq.py, command= bkill -J %s failed with return code -%d  ----" %  (test.jobname, retcode), echo=True)
-                except OSError, e:
+                except OSError as e:
                     log("---- bkill() in lsf_asq.py, execution of command failed (bkill -J %s) failed:  %s----" %  (test.jobname, e), echo=True)

--- a/ats/src/atsMachines/slurmProcessorScheduled.py
+++ b/ats/src/atsMachines/slurmProcessorScheduled.py
@@ -235,14 +235,14 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
         if configuration.options.ompNumThreads > 0:
             test.nt = configuration.options.ompNumThreads
         else:
-            if test.options.has_key('nt'):
+            if 'nt' in test.options:
                 test.nt = test.options.get('nt', 1)
 
         test.cpus_per_task = -1
         if configuration.options.cpusPerTask > -1:
             test.cpus_per_task = configuration.options.cpusPerTask
         else:
-            if test.options.has_key('cpus_per_task'):
+            if 'cpus_per_task' in test.options:
                 test.cpus_per_task = test.options.get('cpus_per_task', 1)
 
         # Command line option toss_nn over-rides what is in the deck.
@@ -494,8 +494,7 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
                         print("             This allocation has %d max processors on %d nodes " % (self.numberMaxProcessors, self.numNodes))
                         print("             Slurm may see your shell as utilizing a process and never")
                         print("             schedule this job to run, resulting in a hang.")
-                        print("ATS ADVICE:  Consider allocating %d nodes for
-                        testing" % (self.numNodes + 1))
+                        print("ATS ADVICE:  Consider allocating %d nodes for testing" % (self.numNodes + 1))
 
             if self.runningWithinSalloc == False:
 

--- a/ats/src/atsMachines/standard.py
+++ b/ats/src/atsMachines/standard.py
@@ -54,7 +54,7 @@ class WinMachine (machines.Machine):
         self.npMax= self.numberTestsRunningMax
 
         if options.numNodes==-1:
-            if os.environ.has_key('NUMBER_OF_PROCESSORS'):
+            if 'NUMBER_OF_PROCESSORS' in os.environ:
                 options.numNodes= int(os.environ['NUMBER_OF_PROCESSORS'])
 
             else:

--- a/ats/src/atsMachines/utils.py
+++ b/ats/src/atsMachines/utils.py
@@ -115,7 +115,7 @@ def getUnusedNode(inNodeAvailTotalDic, inNodeList, desiredAmount, maxProcsPerNod
     maxCount= len(inNodeList)
 
     from operator import itemgetter
-    stepNodeDic= dict([ (v,k) for (k,v) in inNodeStepNumDic.iteritems() ])
+    stepNodeDic= {v: k for k, v in inNodeStepNumDic.items()}
 
     nodeAvailDic= inNodeAvailTotalDic
 
@@ -215,7 +215,7 @@ def removeFromUsedTotalDicNoSrun(inNodeAvailDic, inNodeStepNumDic, inMaxProcsPer
 
     from operator import itemgetter
 
-    stepNodeDic= dict([ (v,k) for (k,v) in inNodeStepNumDic.iteritems() ])
+    stepNodeDic= {v: k for k, v in inNodeStepNumDic.items()}
 
     amountLeft= max(inAmountToDelete, 1)
 
@@ -246,7 +246,7 @@ def removeFromUsedTotalDic (inNodeAvailDic, inNodeStepNumDic, inMaxProcsPerNode,
 
     from operator import itemgetter
 
-    stepNodeDic= dict([ (v,k) for (k,v) in inNodeStepNumDic.iteritems() ])
+    stepNodeDic= {v: k for k, v in inNodeStepNumDic.items()}
 
     amountLeft= max(inAmountToDelete, 1)
 
@@ -386,7 +386,7 @@ def getNodeAndStepIdAssociatedWithStepNumberLinux(inMaxStep):
     #
     #  unset SQUEUE_FORMAT before using "squeue -s"
     #--------------------------------------------------
-    if os.environ.has_key('SQUEUE_FORMAT'):
+    if 'SQUEUE_FORMAT' in os.environ:
         oldSqueueFormatValue= os.environ['SQUEUE_FORMAT']
         os.unsetenv('SQUEUE_FORMAT')
 
@@ -479,7 +479,7 @@ def getNodeAndStepIdAssociatedWithStepNumberLinux(inMaxStep):
 
     #  re-set SQUEUE_FORMAT after using "squeue -s"
     #--------------------------------------------------
-    if os.environ.has_key('SQUEUE_FORMAT'):
+    if 'SQUEUE_FORMAT' in os.environ:
         os.environ['SQUEUE_FORMAT']=  oldSqueueFormatValue
 
     if nodeToCheck == '' or newStep== '':
@@ -492,7 +492,7 @@ def getNodeAndStepIdAssociatedWithStepNumberLinux(inMaxStep):
 def getNumberOfProcessorsPerNode(useNode=None):
     # Assume all nodes on this machine has the same number of processors
 
-    if os.environ.has_key('SYS_TYPE'):
+    if 'SYS_TYPE' in os.environ:
         SYS_TYPE= os.environ['SYS_TYPE']
     else:
         SYS_TYPE= ''
@@ -565,7 +565,7 @@ def getAllSlurmStepIds():
     import getpass, os
 
     envUser= None
-    if not os.environ.has_key('USER'):
+    if 'USER' not in os.environ:
         envUser= getpass.getuser()
     else:
         envUser= os.environ['USER']
@@ -578,7 +578,7 @@ def getAllSlurmStepIds():
 
         theLines = stdOutput.split('\n')
 
-    except OSError, e:
+    except OSError as e:
         theLines= "---- killUsingSlurmStepId, execution of command failed :  %s----" %  (squeueCommand)
 
     return theLines


### PR DESCRIPTION
Applied a range of updates from the 2to3 tool. Ran all fixers available in 2to3 except for the "print" and "import" fixers. print statement updates are already done and updating import statements deserves its own commit with careful testing.
Some fixes like wrapping lots of stuff in "list()" were left out. Rerun "2to3 -x print -x import" if you are curious to see what was left out. 