### PR TITLE
temp fix for building ATS

### DIFF
--- a/ats/setup.py
+++ b/ats/setup.py
@@ -1,0 +1,32 @@
+from setuptools import find_packages, setup
+from modulefinder import ModuleFinder
+
+
+def get_version():
+    finder = ModuleFinder()
+    finder.run_script('version.py')
+    from version import version as version_text
+    return version_text
+
+
+setup(
+    name="ats",
+    author="Shawn A. Dawson",
+    author_email="dawson6@llnl.gov",
+    url="https://github.com/LLNL/ATS",
+    version=get_version(),
+    description="Automated Testing System",
+    install_requires=['numpy <= 1.16.5'],
+    package_dir={'': 'src'},
+    packages=find_packages(
+        where='src',
+    ),
+    entry_points={
+        'console_scripts': [
+            'ats=ats.bin._ats:main',
+            'ats3=ats.bin._ats3:main',
+            'atslite1=atslite.bin._atslite1:main',
+            'atslite3=atslite.bin._atslite3:main'
+        ]
+    }
+)

--- a/ats/tox.ini
+++ b/ats/tox.ini
@@ -5,21 +5,9 @@ envlist = ats
 basepython = python2.7
 deps =
     numpy <= 1.16.5
-whitelist_externals =
-    chmod
-    chgrp
-commands_pre =
-    pip install {toxinidir}/src/LC
 commands =
-    chgrp -R atsb {toxworkdir}/{envname}
-    chmod -R g=u,o=u-w {envsitepackagesdir}/ats \
-                       {envsitepackagesdir}/atsASC \
-                       {envsitepackagesdir}/atsExtras \
-                       {envsitepackagesdir}/atsMachines
-    chmod -R a+x {envsitepackagesdir}/atsASC/checkers/
-commands_post =
     {toxinidir}/src/ats/bin/tox_mv_build {toxworkdir}/{envname} {posargs}
-    {toxinidir}/src/ats/bin/tox_python_update {posargs}
+#    {toxinidir}/src/ats/bin/tox_python_update {posargs}
 # recreate: virtualenv "--clear" flag
 recreate= True
 # sitepackages: virtualenv "--system-site-packages" flag


### PR DESCRIPTION
With this update, ATS can be built via "tox" or locally with "pip" via "python2 -m pip install --user <path to setup.py>".
Tox creates a virtualenv with a python executable and all the built ATS libraries.
pip installs "ats" and "atsMachines" to your python's site packages.