### PR TITLE
update attributedict.py to run with py2 and py3

### DIFF
--- a/ats/src/ats/attributedict.py
+++ b/ats/src/ats/attributedict.py
@@ -1,9 +1,6 @@
-from __future__ import print_function
-from StringIO import StringIO
-
-class AttributeDict (dict):
-    """A dictionary whose items can be accessed as attributes. Be careful not to
-       include attributes with names that are dictionary methods:
+class AttributeDict(dict):
+    """A dictionary whose items can be accessed as attributes. Be careful not
+       to include attributes with names that are dictionary methods:
        'clear', 'copy', 'fromkeys', 'get', 'has_key',
        'items','iteritems', 'iterkeys', 'itervalues', 'keys', 'pop',
        'popitem', 'setdefault', 'update', 'values'
@@ -31,33 +28,21 @@ class AttributeDict (dict):
             raise AttributeError('No attribute %s' % name)
 
     def __repr__(self):
-        out = StringIO()
-        print("AttributeDict(", file=out)
-        keys = self.keys()
-        keys.sort()
-        for key in keys:
-            print("  %s = %r," % (key, self[key]), file=out)
-        print(")", file=out)
-        s = out.getvalue()
-        out.close()
-        return s
+        _repr = "AttributeDict(\n"
+        for key in sorted(self.keys()):
+            _repr += " %s = %r,\n" % (key, self[key])
+        _repr += ")"
+        return _repr
 
     def __str__(self):
         "Prints the attributes in alphabetical order."
-        out = StringIO()
-        keys = self.keys()
-        keys.sort()
-        for key in keys:
-            if key.startswith('_'):
-                next
-            print >>out, key, " = ", str(self[key])
-            print("%s = %s," % (key, self[key]), file=out)
-        s = out.getvalue()
-        out.close()
-        return s
+        _str = ''
+        for key in (k for k in sorted(self.keys()) if not k.startswith('_')):
+            _str += "%s = %s,\n" % (key, self[key])
+        return _str
 
 if __name__ == "__main__":
-    d=AttributeDict(a=1, b=2)
+    d = AttributeDict(a=1, b=2)
     assert d.a == 1
     assert d.b == 2
     d.c = 3


### PR DESCRIPTION
Lots of ATS files import "atsut.py" which then imports "attributedict.py".
Upgrading most of ATS to python 3 relies on "attributedict.py" being able to run in python 3.