### PR TITLE
Slurm version aware and other fixes.

### DIFF
--- a/ats/src/ats/configuration.py
+++ b/ats/src/ats/configuration.py
@@ -55,6 +55,7 @@ def addOptions(parser):
     parser.set_defaults(
         allInteractive=False,
         combineOutErr=False,
+        unbuffered=False,
         strict_nn=False,
         mpi_um=False,
         bypassSerialMachineCheck=False,
@@ -142,6 +143,9 @@ def addOptions(parser):
 
     # Toss specific options
     if SYS_TYPE.startswith('toss'):
+        parser.add_option('--unbuffered', action='store_true', dest='unbuffered',
+            help='Toss3 option: Pass srun the --unbuffered option.')
+
         parser.add_option('--mpibind', action='store', type='string', dest='mpibind',
             help='Toss3 option: Specify slurm --mpibind plugin options to use. By default, ATS specifies --mpibind=off on Toss 3 systems, but projects may want other options.  Common options are none, on, off.  srun --mpibind=help will show further options.')
 

--- a/ats/src/ats/management.py
+++ b/ats/src/ats/management.py
@@ -965,7 +965,7 @@ BATCHED = ats.BATCHED
         remaining = {}
         for t in self.testlist:
             if t not in interactiveTests:
-                print("testlist[%d].set(SKIPPED, 'was %s') # %s" %
+                print("testlist[%d].set(SKIPPED, 'was %s') # %s" % \
                       (t.serialNumber - 1, t.status.name, t.name), file=fc)
             else:
                 remaining[t.serialNumber] = t
@@ -981,7 +981,7 @@ BATCHED = ats.BATCHED
                     break
             else:
                 for v in brothers:
-                    print("testlist[%d].set(%s, 'Previously ran.') # %s"
+                    print("testlist[%d].set(%s, 'Previously ran.') # %s" % \
                           (v.serialNumber - 1, v.status.name, v.name), file=fc)
 
         fc.close()


### PR DESCRIPTION
Update slurm module so it knows
what slurm version is being used. This
is needed due to differences in how
slurm behaves with the update by SchedMD.
The new slurm is on one machine for testing,
other machines have the older slurm.

Fix print statement.  A '%' character
had been lost in the conversion of print
statements to be python 3 compatible.

Remove use of --share when constructing
srun line.  This option is deprecated
and is not supported in current slurm.

Added --unbuffered option at the request
of ATS user.  If specified, will add
-unbuffered to the srun line.  The user
wants to see if this helps them better
view the output from a run.  This is off
by default.

Change miscellaneous use of "-v" when
constructiong the srun line to use
--comment="xxx".  These options can
not be blank, as that breaks the run
under python.  They have to be something.
I was using the -v, which turns on
a more verbose srun run.  But the --comment
is a better no-op in these situations.

Placeholder to better explore --exclusve=user
option. I have not implemented this, as in
my testing it results in some interconnect
errors.  This was suggested by ans ATS user
as well.