### PR TITLE
Change prints to atsr.py.

### DIFF
--- a/ats/src/ats/attributedict.py
+++ b/ats/src/ats/attributedict.py
@@ -30,7 +30,7 @@ class AttributeDict(dict):
     def __repr__(self):
         _repr = "AttributeDict(\n"
         for key in sorted(self.keys()):
-            _repr += " %s = %r,\n" % (key, self[key])
+            _repr += "   %s  =  %r ,\n" % (key, self[key])
         _repr += ")"
         return _repr
 

--- a/ats/src/ats/management.py
+++ b/ats/src/ats/management.py
@@ -1128,7 +1128,7 @@ dependents_serial contain the serial numbers of the relevant tests.
         "Print state to file, formatting items with repr"
 # import * is bad style but helps with robustness with respect to ats changes:
         print("""from ats import *""", file=file)
-        print("state = ", file=file)
+        print("state =  ", file=file, end='')
         print(repr(self.getResults()), file=file)
         print("logDirectory = %r" % log.directory, file=file)
         print("machineName = %r" % self.machine.name, file=file)


### PR DESCRIPTION
While not 100% identical to the 6.x version
of the code, this is update makes the created
atsr.py files, which projects rely upon,
to be much closer to the 6.x version.

This should fix issues reported by a user.