### PR TITLE
fix faulty AtsTest comparisons

### DIFF
--- a/ats/tests.py
+++ b/ats/tests.py
@@ -324,7 +324,7 @@ class AtsTest (object):
                     "Changed to batch since unable to run interactively on this machine.")
 
     def __hash__(self):
-        return hash(self.totalPriority)
+        return hash(self.serialNumber)
 
     def __ge__(self, other):
         return self.totalPriority >= other.totalPriority
@@ -339,10 +339,10 @@ class AtsTest (object):
         return self.totalPriority < other.totalPriority
 
     def __eq__(self, other):
-        return self.totalPriority == other.totalPriority
+        return self.serialNumber == other.serialNumber
 
     def __ne__(self, other):
-        return self.totalPriority != other.totalPriority
+        return self.serialNumber != other.serialNumber
 
     def __invert__ (self):
         """Responds to the ~ operator by setting the expected status FAILED,


### PR DESCRIPTION
ATS tests were being scheduled out of order due to how two AtsTest instances were being compared.

[Line 644 in ats/management.py](https://github.com/LLNL/ATS/blob/main/ats/management.py#L644) was erroneously checking for tests not in a list based on the test's "totalPriority" attribute. Two tests with the same "totalPriority" would be considered equivalent. Unlike "totalPriority", a test's "serialNumber" attribute is unique and should have been referenced from the beginning.
ATS instructs some tests to wait until a list of other tests have completed before beginning. This list of dependent tests was incomplete and this update fixes this sneaky problem.