### PR TITLE
DRAFT: repurpose unused option to toggle atss logging

### DIFF
--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -114,7 +114,7 @@ def addOptions(parser):
         logdir='',
         level=0,
         npMax=0,
-        logUsage=False,
+        logUsage=True,
         okInvalid=False,
         oneFailure=False,
         reportFreq=1,
@@ -315,13 +315,8 @@ statement at the start of the input.""")
         help="Max number of cores per node to utilize. Overrides default ATS detection of cores per node.")
 
     parser.add_option('--noUsageLogging', action='store_false',
-                      dest = 'logUsage',
+                      dest='logUsage',
         help='Turn off logging ATS usage.  (Code and '
-             'test names are never logged.)')
-
-    parser.add_option('--usageLogging', action='store_true',
-                      dest = 'logUsage',
-        help='Turn on logging ATS usage.  (Code and '
              'test names are never logged.)')
 
     parser.add_option('--okInvalid', action='store_true', dest='okInvalid',

--- a/ats/schedulers.py
+++ b/ats/schedulers.py
@@ -27,8 +27,10 @@ class StandardScheduler (object):
         machine = configuration.machine
         self.verbose = configuration.options.verbose or debug() or \
                        configuration.options.skip
-        self.schedule = AtsLog(directory=log.directory, name='atss.log',
-            logging=True, echo=False)
+        self.schedule = AtsLog(directory=log.directory,
+                               name='atss.log',
+                               logging=configuration.options.logUsage,
+                               echo=False)
 
         for t in interactiveTests:
             waitOnMe = [x for x in interactiveTests if t in x.waitUntil]


### PR DESCRIPTION
Make use of seemingly unused command line option to toggle logging to `atss.log` file.
[Logging to atss.log consumes large amounts of disk space](https://github.com/LLNL/ATS/issues/70) for some projects. This PR aims to provide an opt-out option for projects not interested in this log.