### PR TITLE
remove unused Blueos option mpi_um

### DIFF
--- a/ats/atsMachines/lsf_asq.py
+++ b/ats/atsMachines/lsf_asq.py
@@ -162,7 +162,6 @@ class lsfMachine (machines.Machine):
         self.blueos_np        = options.blueos_np
         self.cpusPerTask      = options.cpusPerTask
         self.timelimit        = options.timelimit
-        self.mpi_um           = options.mpi_um
 
         #if self.lrun_pack and self.lrun_pack == False:
         #    print("DBG 101 self.lrun_pack = False")
@@ -313,7 +312,6 @@ class lsfMachine (machines.Machine):
         test.lrun_pack       = self.lrun_pack
         test.lrun_jsrun_args = self.lrun_jsrun_args
         test.ompProcBind     = self.ompProcBind
-        test.mpi_um          = self.mpi_um
 
         if lsfMachine.debugJsrun:
             print("JSRUN 020 DEBUG lsf_asq test.jsrun_omp          =  %s " % test.jsrun_omp)
@@ -356,9 +354,6 @@ class lsfMachine (machines.Machine):
         str_mpibind = "/usr/tce/bin/mpibind"
         if self.mpibind_executable != "unset":
             str_mpibind = self.mpibind_executable
-
-        #if test.mpi_um == True:
-        #    str_smpi = "--smpiargs=\"-gpu\""
 
         if configuration.options.blueos_ngpu and configuration.options.blueos_ngpu >= 0:
             test.ngpu = configuration.options.blueos_ngpu

--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -74,7 +74,6 @@ def addOptions(parser):
         combineOutErr=False,
         unbuffered=False,
         strict_nn=False,
-        mpi_um=False,
         bypassSerialMachineCheck=False,
         exclusive=True,
         mpibind='off',
@@ -134,12 +133,6 @@ def addOptions(parser):
 
     parser.add_option('--strict_nn', action='store_true', dest='strict_nn',
         help='Strictly observe test "nn" options, this may result in reduced througput or even slurm srun hangs.')
-
-    parser.add_option('--m_gpu', action='store_true', dest='mpi_um',
-        help='Blueos option: Deprecated option. --smpiargs=-gpu will be added by default to support MPI access to unified memory. Synonym with --smpi_gpu')
-
-    parser.add_option('--smpi_gpu', action='store_true', dest='mpi_um',
-        help='Blueos option: Deprecated option. --smpiargs=-gpu will be added by default to support MPI access to unified memory. Synonym with --m_gpu')
 
     parser.add_option('--bypassSerialMachineCheck', action='store_true', dest='bypassSerialMachineCheck',
         help='Bypass check which prohibits ATS from running on serial machines such as rztrona or borax.')


### PR DESCRIPTION
Small step toward upgrading ATS's use of [optparse](https://docs.python.org/3/library/optparse.html "Deprecated since Python 3.2") to [argparse](https://docs.python.org/3/library/argparse.html).