### PR TITLE
update kripke test, remove external dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 include:
+  - local: .gitlab/kripke.yml
   - local: .gitlab/runners.yml
 
 stages:
@@ -7,13 +8,17 @@ stages:
 default:
   interruptible: true
 
-.hello_ATS:
-  stage: test
-  script:
+.install_ATS:
+  before_script:
     - ml python/3.8
     - python3 -m virtualenv --python=python3.8 TEST_VENV
     - source TEST_VENV/bin/activate
     - pip install .
+
+.hello_ATS:
+  extends: .install_ATS
+  stage: test
+  script:
     - cd test/HelloATS
     - mpicc hello_ats.c
     - atslite1
@@ -23,7 +28,15 @@ default:
       test/HelloATS/$SYS_TYPE*.logs/ats.log
 
 hello_ATS_TOSS:
-  extends: [.hello_ATS, .run_quartz_shell]
+  extends: [.hello_ATS, .run_borax_shell]
 
 #hello_ATS_BLUEOS:
 #  extends: [.hello_ATS, .run_lassen_shell]
+
+test-kripke:
+  extends: .run_quartz_shell
+  before_script:
+    - !reference [.install_ATS, before_script]
+    - !reference [.kripke_setup, before_script]
+  script:
+    - !reference [.kripke_test, script]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,7 @@ hello_ATS_TOSS:
 #  extends: [.hello_ATS, .run_lassen_shell]
 
 test-kripke:
+  stage: test
   extends: .run_quartz_shell
   before_script:
     - !reference [.install_ATS, before_script]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ default:
       test/HelloATS/$SYS_TYPE*.logs/ats.log
 
 hello_ATS_TOSS:
-  extends: [.hello_ATS, .run_borax_shell]
+  extends: [.hello_ATS, .run_quartz_shell]
 
 #hello_ATS_BLUEOS:
 #  extends: [.hello_ATS, .run_lassen_shell]

--- a/.gitlab/kripke.yml
+++ b/.gitlab/kripke.yml
@@ -8,8 +8,8 @@ variables:
   before_script:
     - cd $KRIPKE_PATH
     - >
-      curl --header "JOB-TOKEN $CI_JOB_TOKEN"
-      ${ATS_PACKAGE_URL}/${KRIPKE_PACKAGE_URL}/${KRIPKE_FILE}
+      curl --header "JOB-TOKEN: $CI_JOB_TOKEN" -O
+      "${ATS_PACKAGE_URL}/${KRIPKE_PACKAGE_URL}/${KRIPKE_FILE}"
     - tar -xvzf kripke-v1.2.5-20e9ea9.tar.gz
     - cd kripke-v1.2.5-20e9ea9
     - mkdir build

--- a/.gitlab/kripke.yml
+++ b/.gitlab/kripke.yml
@@ -1,0 +1,23 @@
+variables:
+  ATS_API_URL: $CI_API_V4_URL/projects/$CI_PROJECT_ID/packages
+  KRIPKE_PACKAGE_URL: generic/kripke/v1.2.5
+  KRIPKE_FILE: kripke-v1.2.5-20e9ea9.tar.gz
+  KRIPKE_PATH: $CI_PROJECT_DIR/test/Kripke
+
+.kripke_setup:
+  before_script:
+    - cd $KRIPKE_PATH
+    - >
+      curl --header "JOB-TOKEN $CI_JOB_TOKEN"
+      ${ATS_PACKAGE_URL}/${KRIPKE_PACKAGE_URL}/${KRIPKE_FILE}
+    - tar -xvzf kripke-v1.2.5-20e9ea9.tar.gz
+    - cd kripke-v1.2.5-20e9ea9
+    - mkdir build
+    - cd build
+    - cmake .. -C../host-configs/llnl-toss3-gcc8.1.cmake -DCMAKE_BUILD_TYPE=Release
+    - make -j8
+
+.kripke_test:
+  script:
+    - cd $KRIPKE_PATH
+    - atslite1

--- a/.gitlab/kripke.yml
+++ b/.gitlab/kripke.yml
@@ -9,7 +9,7 @@ variables:
     - cd $KRIPKE_PATH
     - >
       curl --header "JOB-TOKEN: $CI_JOB_TOKEN" -O
-      "${ATS_PACKAGE_URL}/${KRIPKE_PACKAGE_URL}/${KRIPKE_FILE}"
+      "${ATS_API_URL}/${KRIPKE_PACKAGE_URL}/${KRIPKE_FILE}"
     - tar -xvzf kripke-v1.2.5-20e9ea9.tar.gz
     - cd kripke-v1.2.5-20e9ea9
     - mkdir build

--- a/.gitlab/runners.yml
+++ b/.gitlab/runners.yml
@@ -4,11 +4,24 @@
 ._shell:
   tags: &shell shell
 
+._borax:
+  tags: &borax borax
+
 ._lassen:
   tags: &lassen lassen
 
 ._quartz:
   tags: &quartz quartz
+
+.run_borax_batch:
+  tags:
+    - *borax
+    - *batch
+
+.run_borax_shell:
+  tags:
+    - *borax
+    - *shell
 
 .run_lassen_batch:
   tags:

--- a/test/Kripke/README.txt
+++ b/test/Kripke/README.txt
@@ -11,14 +11,14 @@ This testing was based on the tarfile kripke-v1.2.5-20e9ea9.tar.gz from the abov
 
 1) Build Kripke in this directory (test/Kripke)
 
-gunzip kripke-v1.2.5-20e9ea9.tar.gz
-tar -xvf kripke-v1.2.5-20e9ea9.tar 
+pushd .
+tar -xvzf kripke-v1.2.5-20e9ea9.tar.gz
 cd kripke-v1.2.5-20e9ea9
 mkdir build
 cd build
 cmake .. -C../host-configs/llnl-toss3-gcc8.1.cmake -DCMAKE_BUILD_TYPE=Release
 make -j 8
-cd ../..
+popd
 
 
 2) Run Kripke under ATS.  Some examples are:

--- a/test/Kripke/ats_check_log.py
+++ b/test/Kripke/ats_check_log.py
@@ -1,33 +1,15 @@
-#!/usr/apps/ats/7.0.4/bin/python
+#!/usr/bin/env python3
 import os
 import sys
 
 if __name__ == '__main__':
-    pwd = os.getcwd()
-
-    if len(sys.argv) < 2:
-        sys.exit(1)
+    assert len(sys.argv) < 2, "Expected 1 argument or none."
 
     logfile = sys.argv[1]
+    assert os.path.exists(logfile), f"File '{logfile}' not found."
 
-    if os.path.exists(logfile):
+    with open(logfile) as _file:
+        log_file_text = _file.read()
 
-        f = open( logfile, 'r')
-        lines = f.readlines()
-        f.close
-
-        for line in lines:
-            if "Differences found" in line:
-                print "test did not pass"
-                sys.exit(1)
-
-        # If we get to here, we found no differences
-        # test was good
-        print "test passed"
-        sys.exit(0)
-
-    # If we get to here, we did not find the log file
-    print "test did not pass"
-    sys.exit(1)
-
-# end of file
+    assert "Differences found" not in log_file_text, "test did not pass"
+    print("test passed")

--- a/test/Kripke/create_test_ats.py
+++ b/test/Kripke/create_test_ats.py
@@ -1,72 +1,97 @@
-#!/usr/apps/ats/7.0.4/bin/python
-from __future__ import print_function
+#!/usr/bin/env python3
 import os
 import sys
 
-independent=True
-sandbox=False
 
-ABS_FILE_PATH = os.path.dirname(os.path.realpath(__file__))
-checker = os.path.join(ABS_FILE_PATH, 'ats_check_log.py')
-test_ats="test.ats"
-code = os.path.join(ABS_FILE_PATH, 'kripke-v1.2.5-20e9ea9/build/bin/kripke.exe')
+KRIPKE_PATH = os.path.dirname(os.path.realpath(__file__))
+TEST_ATS = "test.ats"
 
-test_ats="test.ats"
 
-# -------------------------------------------------------------------------------------------------
-# Define the sequential test runs here
-# -------------------------------------------------------------------------------------------------
-nprocs=[1]
-nprocs_code_args=['']
+def create_ats_file(nprocs, nprocs_code_args, code, args, init_test_num=0):
+    test_num = init_test_num or 1
+    write_mode = 'a' if init_test_num else 'w'
 
-code_args=['--layout dgz ',
-           '--layout dzg ',
-           '--layout gdz ',
-           '--layout gzd ',
-           '--layout zdg ',
-           '--layout zgd ',
-           '--layout dgz  --zset 2,4,8 --gset 2 --groups 6 ',
-           '--layout dzg  --zset 2,4,8 --gset 2 --groups 6 ',
-           '--layout gdz  --zset 2,4,8 --gset 2 --groups 6 ',
-           '--layout gzd  --zset 2,4,8 --gset 2 --groups 6 ',
-           '--layout zdg  --zset 2,4,8 --gset 2 --groups 6 ',
-           '--layout zgd  --zset 2,4,8 --gset 2 --groups 6 ',
-           '--layout dgz  --zset 2,4,8 --gset 2 --groups 6 ',
-           '--layout dgz  --pmethod bj'
-          ]
+    if init_test_num:
+        file_contents = ""
+    else:
+        file_contents = "\n".join([
+            "import os",
+            "glue(independent=True)",
+            "glue(keep=True)",
+            f"my_checker = '{KRIPKE_PATH}/ats_check_log.py'\n",
+        ])
 
-# -------------------------------------------------------------------------------------------------
-# Define parallel tests here.
-# Broken out into two sections as I noticed that not all of the sequential tests may be run
-# in parallel.
-# -------------------------------------------------------------------------------------------------
-nprocs_2=[2, 4, 8, 16, 16]
-nprocs_code_args_2=['--procs 2,1,1', '--procs 2,2,1', '--procs 2,2,2', '--procs 2,2,4', '--procs 4,4,1']
+    for nprocs_ndx, nproc in enumerate(nprocs):
+        for arg in args:
+            test_line = " ".join([
+                f"t{test_num}=test ",
+                f"(executable = '{code}',",
+                f"clas = '{nprocs_code_args[nprocs_ndx]} {arg}',",
+                f"label='{code}_{test_num}',",
+                f"np={nproc},",
+                "sandbox=False)\n",
+            ])
+            testif_line = " ".join([
+                f"t{test_num + 1}=testif(t{test_num},",
+                "executable = my_checker,",
+                f"clas = t{test_num}.outname,",
+                "nosrun=True)\n",
+            ])
+            test_num += 2
+            file_contents += test_line
+            file_contents += testif_line
 
-code_args_2=['--layout dgz ',
-             '--layout dzg ',
-             '--layout gdz ',
-             '--layout gzd ',
-             '--layout zdg ',
-             '--layout zgd ',
-             '--layout dgz  --pmethod bj'
-            ]
+    with open(TEST_ATS, write_mode) as ats_file:
+        ats_file.write(file_contents)
+    return test_num
 
-# -------------------------------------------------------------------------------------------------
-# Main.  Call ATS routine to use the above data to create a test.ats file
-# -------------------------------------------------------------------------------------------------
-#tempstr = sys.executable
-#atsModulesDir  = tempstr.replace('bin/python','')
-#atsASC_Modules_dir = os.path.join(atsModulesDir, 'atsASC/modules')
-#sys.path.append( atsASC_Modules_dir )
 
-from atsASC.modules.ASC_utils import create_ats_file_version_004
+if __name__ == "__main__":
+    code = os.path.join(KRIPKE_PATH,
+                        'kripke-v1.2.5-20e9ea9/build/bin/kripke.exe')
 
-if __name__=="__main__":
+    # Define sequential test runs
+    nprocs = [1]
+    nprocs_code_args = ['']
+    code_args = [
+        '--layout dgz ',
+        '--layout dzg ',
+        '--layout gdz ',
+        '--layout gzd ',
+        '--layout zdg ',
+        '--layout zgd ',
+        '--layout dgz  --zset 2,4,8 --gset 2 --groups 6 ',
+        '--layout dzg  --zset 2,4,8 --gset 2 --groups 6 ',
+        '--layout gdz  --zset 2,4,8 --gset 2 --groups 6 ',
+        '--layout gzd  --zset 2,4,8 --gset 2 --groups 6 ',
+        '--layout zdg  --zset 2,4,8 --gset 2 --groups 6 ',
+        '--layout zgd  --zset 2,4,8 --gset 2 --groups 6 ',
+        '--layout dgz  --zset 2,4,8 --gset 2 --groups 6 ',
+        '--layout dgz  --pmethod bj',
+    ]
+    # Create sequential entries in test.ats file.
+    last_t = create_ats_file(nprocs, nprocs_code_args, code, code_args)
 
-    # First create sequential entries in test.ats file.
-    # Then append parallel tests into the same test.ats file 
-    last_t = create_ats_file_version_004(independent, checker, test_ats, nprocs,   nprocs_code_args,   code, code_args,   sandbox)
-    last_t = create_ats_file_version_004(independent, checker, test_ats, nprocs_2, nprocs_code_args_2, code, code_args_2, sandbox, last_t)
+    # Define parallel test runs
+    nprocs = [2, 4, 8, 16, 16]
+    nprocs_code_args = [
+        '--procs 2,1,1',
+        '--procs 2,2,1',
+        '--procs 2,2,2',
+        '--procs 2,2,4',
+        '--procs 4,4,1',
+    ]
+    code_args = [
+        '--layout dgz ',
+        '--layout dzg ',
+        '--layout gdz ',
+        '--layout gzd ',
+        '--layout zdg ',
+        '--layout zgd ',
+        '--layout dgz  --pmethod bj',
+    ]
 
-# end of file
+    # Append parallel tests into the same test.ats file
+    create_ats_file(nprocs, nprocs_code_args, code, code_args, last_t)
+
+    print(f"Most Excellent! Created ats test file {TEST_ATS}")

--- a/test/Kripke/postrun.py
+++ b/test/Kripke/postrun.py
@@ -1,5 +1,4 @@
-#!/usr/apps/ats/7.0.4/bin/python
-import os
+#!/usr/bin/env python3
 import sys
 
 # 2016-Oct-18 Initial script setup by Shawn Dawson
@@ -22,13 +21,8 @@ import sys
 # to get us started.
 #
 
-if __name__=="__main__":
-
-    print "Hello From Post Run Script"
+if __name__ == "__main__":
+    print("Hello From Post Run Script")
 
     for index, arg in enumerate(sys.argv):
-        print "Argument %d : %s" % (index, arg)
-
-    sys.exit(0)
-
-# end of file
+        print(f"Argument {index}: {arg}")

--- a/test/Kripke/prerun.py
+++ b/test/Kripke/prerun.py
@@ -1,5 +1,4 @@
-#!/usr/apps/ats/7.0.4/bin/python
-import os
+#!/usr/bin/env python3
 import sys
 
 # 2016-Oct-18 Initial script setup by Shawn Dawson
@@ -22,13 +21,8 @@ import sys
 # to get us started.
 #
 
-if __name__=="__main__":
-
+if __name__ == "__main__":
     print "Hello From Pre Run Script"
 
     for index, arg in enumerate(sys.argv):
-        print "Argument %d : %s" % (index, arg)
-
-    sys.exit(0)
-
-# end of file
+        print(f"Argument {index}: {arg}")


### PR DESCRIPTION
Test setup for Kripke testing needed updating and some bugfixes.

- `create_test_ats.py` was trying to import from an external ATS related repository. The external code has been brought into this repo.
- Some print statements have been updated from Python 2.7 format to Python 3 format.
- Attempted to make the code more readable in general.