### PR TITLE
Feature/bloss1/add ats file parser

### DIFF
--- a/ats/management.py
+++ b/ats/management.py
@@ -6,6 +6,7 @@ from ats.atsut import INVALID, PASSED, FAILED, SKIPPED, BATCHED, LSFERROR, \
 from ats.times import datestamp, Duration, wallTime, atsStartTimeLong
 from ats.tests import AtsTest
 from ats.log import log, terminal
+from ats.parser import AtsCodeParser, AtsFileParser
 
 def standardIntrospection(line):
     "Standard magic detector for input."
@@ -237,7 +238,10 @@ Attributes:
                     log(line, echo=False)
             os.chdir(directory)
             try:
-                exec(code, testenv)
+                parser = AtsCodeParser(code)
+                parsed_text = parser.get_parsed_text()
+                for line in parsed_text.splitlines():
+                    exec(line, testenv)
                 if debug():
                     log('Finished ', t1, datestamp())
             except KeyboardInterrupt:
@@ -252,7 +256,10 @@ Attributes:
             log.indent()
             os.chdir(directory)
             try:
-                exec(compile(open(t1, "rb").read(), t1, 'exec'), testenv)
+                parser = AtsFileParser(t1)
+                parsed_text = parser.get_parsed_text()
+                for line in parsed_text.splitlines():
+                    exec(line, testenv)
                 if debug(): log('Finished ', t1, datestamp())
                 result = 1
             except KeyboardInterrupt:

--- a/ats/management.py
+++ b/ats/management.py
@@ -239,9 +239,8 @@ Attributes:
             os.chdir(directory)
             try:
                 parser = AtsCodeParser(code)
-                parsed_text = parser.get_parsed_text()
-                for line in parsed_text.splitlines():
-                    exec(line, testenv)
+                for code_segment in parser.get_code_iterator():
+                    exec(code_segment, testenv)
                 if debug():
                     log('Finished ', t1, datestamp())
             except KeyboardInterrupt:
@@ -257,9 +256,8 @@ Attributes:
             os.chdir(directory)
             try:
                 parser = AtsFileParser(t1)
-                parsed_text = parser.get_parsed_text()
-                for line in parsed_text.splitlines():
-                    exec(line, testenv)
+                for code_segment in parser.get_code_iterator():
+                    exec(code_segment, testenv)
                 if debug(): log('Finished ', t1, datestamp())
                 result = 1
             except KeyboardInterrupt:

--- a/ats/parser.py
+++ b/ats/parser.py
@@ -1,5 +1,7 @@
 import ast
 import itertools
+from pathlib import Path
+import re
 import sys
 
 class AtsCodeParser:
@@ -9,44 +11,56 @@ class AtsCodeParser:
         self.ast = ast.parse(code_text)
         self.raw_text = code_text
         self.raw_text_dict = dict(enumerate(code_text.splitlines(), 1))
+        self._parsed_text = ''
+
+    @property
+    def parsed_text(self) -> str:
+        """Filters out comments and other lines determined non-executable."""
+        if not self._parsed_text:
+            line_nums = self._get_code_line_nums()
+            self._parsed_text = "\n".join([self.raw_text_dict[num]
+                                           for num in line_nums])
+        return self._parsed_text
+
+    def _get_code_line_nums(self) -> list:
+        """Sorted list of line numbers of executable Python code."""
+        line_nums = [self._get_node_line_nums(node) for node in self.ast.body]
+        return sorted(itertools.chain.from_iterable(line_nums))
 
     def _get_node_line_nums(self, node: ast.AST) -> list:
         """Get list of line numbers from node of an abstract syntax tree."""
         return list(range(node.lineno, node.end_lineno + 1))
 
-    def get_code_line_nums(self) -> list:
-        """Sorted list of line numbers of executable Python code."""
-        line_nums = [self._get_node_line_nums(node) for node in self.ast.body]
-        return sorted(itertools.chain.from_iterable(line_nums))
+    def get_code_iterator(self):
+        """Get generator to iterate over code segments. Derived from ast nodes.
 
-    def get_parsed_text(self) -> str:
-        line_nums = self.get_code_line_nums()
-        return "\n".join([self.raw_text_dict[num] for num in line_nums])
+        Segments may contain a single line of code for simple expressions or
+        multiple lines of code as found in loops and conditional statements."""
+        source = self.parsed_text
+        return (ast.get_source_segment(source, node) for node in self.ast.body)
 
 
 class AtsFileParser(AtsCodeParser):
     """Parse input files into an ATS consumable format."""
 
     ATS_HEADER = '#ATS:'
+    PATTERN = re.compile(f'^{ATS_HEADER}', re.MULTILINE)
 
     def __init__(self, filename: str) -> None:
         with open(filename) as _file:
-            file_contents = _file.read()
-        super().__init__(file_contents)
+            text = _file.read()
         self._filename = filename
-        lineno_to_text = dict(enumerate(file_contents.splitlines(), 1))
-        self.ATS_lines = {lineno: txt for lineno, txt in lineno_to_text.items()
-                          if txt.startswith(self.ATS_HEADER)}
+        self.ATS_lines = {line_number: line_text for line_number, line_text in
+                          enumerate(text.splitlines(), 1)
+                          if line_text.startswith(self.ATS_HEADER)}
+        text_no_ATS_header = re.sub(self.PATTERN, '', text)
+        super().__init__(text_no_ATS_header)
 
     @property
     def filename(self) -> str:
         return self._filename
 
-    def get_ATS_line_nums(self) -> list:
+    @property
+    def ATS_line_nums(self) -> list:
         """Sorted list of line numbers starting with '#ATS:'"""
         return sorted(self.ATS_lines.keys())
-
-    def get_parsed_text(self) -> str:
-        line_nums = self.get_ATS_line_nums() + super().get_code_line_nums()
-        parsed_text = [self.raw_text_dict[num] for num in sorted(line_nums)]
-        return "\n".join(parsed_text)

--- a/ats/parser.py
+++ b/ats/parser.py
@@ -8,7 +8,7 @@ class AtsCodeParser:
     def __init__(self, code_text: str) -> None:
         self.ast = ast.parse(code_text)
         self.raw_text = code_text
-        self.raw_text_dict = dict(enumerate(code_text.split(sep="\n"), 1))
+        self.raw_text_dict = dict(enumerate(code_text.splitlines(), 1))
 
     def _get_node_line_nums(self, node: ast.AST) -> list:
         """Get list of line numbers from node of an abstract syntax tree."""
@@ -34,7 +34,7 @@ class AtsFileParser(AtsCodeParser):
             file_contents = _file.read()
         super().__init__(file_contents)
         self._filename = filename
-        lineno_to_text = dict(enumerate(file_contents.split(sep="\n"), 1))
+        lineno_to_text = dict(enumerate(file_contents.splitlines(), 1))
         self.ATS_lines = {lineno: txt for lineno, txt in lineno_to_text.items()
                           if txt.startswith(self.ATS_HEADER)}
 

--- a/ats/parser.py
+++ b/ats/parser.py
@@ -1,0 +1,52 @@
+import ast
+import itertools
+import sys
+
+class AtsCodeParser:
+    """Parse ATS code into an ATS consumable format."""
+
+    def __init__(self, code_text: str) -> None:
+        self.ast = ast.parse(code_text)
+        self.raw_text = code_text
+        self.raw_text_dict = dict(enumerate(code_text.split(sep="\n"), 1))
+
+    def _get_node_line_nums(self, node: ast.AST) -> list:
+        """Get list of line numbers from node of an abstract syntax tree."""
+        return list(range(node.lineno, node.end_lineno + 1))
+
+    def get_code_line_nums(self) -> list:
+        """Sorted list of line numbers of executable Python code."""
+        line_nums = [self._get_node_line_nums(node) for node in self.ast.body]
+        return sorted(itertools.chain.from_iterable(line_nums))
+
+    def get_parsed_text(self) -> str:
+        line_nums = self.get_code_line_nums()
+        return "\n".join([self.raw_text_dict[num] for num in line_nums])
+
+
+class AtsFileParser(AtsCodeParser):
+    """Parse input files into an ATS consumable format."""
+
+    ATS_HEADER = '#ATS:'
+
+    def __init__(self, filename: str) -> None:
+        with open(filename) as _file:
+            file_contents = _file.read()
+        super().__init__(file_contents)
+        self._filename = filename
+        lineno_to_text = dict(enumerate(file_contents.split(sep="\n"), 1))
+        self.ATS_lines = {lineno: txt for lineno, txt in lineno_to_text.items()
+                          if txt.startswith(self.ATS_HEADER)}
+
+    @property
+    def filename(self) -> str:
+        return self._filename
+
+    def get_ATS_line_nums(self) -> list:
+        """Sorted list of line numbers starting with '#ATS:'"""
+        return sorted(self.ATS_lines.keys())
+
+    def get_parsed_text(self) -> str:
+        line_nums = self.get_ATS_line_nums() + super().get_code_line_nums()
+        parsed_text = [self.raw_text_dict[num] for num in sorted(line_nums)]
+        return "\n".join(parsed_text)


### PR DESCRIPTION
Parse generic input ATS files to allow line by line interpretation. This greatly improves debugging bad input files, allows greater flexibility, readability, and provides a path away from `exec()` calls in the code.

Python's builtin `ast` (abstract syntax tree) module is used as a superior alternative to regex/text parsing. `ast` also allows for sophisticated handling of generic input files in the future.