### PR TITLE
flux: add compatibility for Flux in the ATS codebase

### DIFF
--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -1,0 +1,142 @@
+#ATS:flux00             SELF FluxScheduled 3
+
+"""
+This module defines the ``FluxScheduled`` class.
+Allocation and flux session managed by `atsflux`. See /bin/atsflux.py for more details.
+
+Author: William Hobbs
+        <hobbs17@llnl.gov>
+
+"""
+
+import time
+from math import ceil
+
+import flux
+import flux.job
+
+from ats import terminal
+from ats.tests import AtsTest
+from ats.atsMachines import lcMachines
+
+class FluxScheduled(lcMachines.LCMachineCore):
+    """
+    A class to initialize Flux if necessary and return job statements
+    from ATS tests.
+    """
+
+    def init(self):
+        """
+        Sets ceiling on number of nodes and cores in the allocation.
+        Defines a persistent handle to use to connect to the broker.
+        """
+        # import pdb
+        # pdb.set_trace()
+        self.fluxHandle = flux.Flux()
+        self.numNodes = int(flux.resource.list.resource_list(self.fluxHandle).get().up.nnodes)
+        self.maxCores = int(flux.resource.list.resource_list(self.fluxHandle).get().up.ncores)
+        self.coresPerNode = self.maxCores // self.numNodes
+        self.numberTestsRunningMax = self.maxCores
+
+    def examineOptions(self, options):
+        """
+        Optparse (soon argparse) parameters from command-line options
+        for ATS users. Needed for functionality with .ats files.
+        
+        :param options: The options available to a user in test.ats files.
+        """
+        self.exclusive = options.exclusive
+        self.timelimit = options.timelimit
+
+    def calculateCommandList(self, test):
+        """
+        Generates a list of commands to run a test in ATS on a 
+        flux instance.
+        
+        :param test: the test to be run, of type ATSTest. Defined in /ats/tests.py.
+        """
+        ret = "flux mini run".split()
+        np = test.options.get('np', 1)
+        nn = test.options.get('nn', 1)
+
+        # David/Shawn: Time limit compatibility -- how do ATS users specify time limits?
+        # with flux, you have to specify a number, and then m, s, or h, and only one can be specified
+        max_time = test.options.get('timelimit', '29m')
+        ret.append(f"-t{max_time}")
+
+        if np > self.coresPerNode:
+            nn = ceil(np / self.coresPerNode)
+        if nn > 0:
+            ret.append(f"-N{nn}")
+
+        """Thread subscription interface. Flux does not oversubscribe cores by default."""
+        nt = test.options.get('nt', 1)
+        """
+        In order to marry ATS's description of threading with Flux's understanding, Flux will
+        request 1 core per thread
+        """
+        ret.append(f"-n{np}")
+        ret.append(f"-c{nt}")
+
+        """GPU scheduling interface"""
+        ngpu = test.options.get('ngpu',0)
+        if ngpu:
+            ret.append(f"-g{ngpu}")
+
+        """Node-exclusive job scheduling: even if a job does not use the entire resources."""
+        if test.options.get('exclusive', False):
+            ret.append("--exclusive")
+        
+        """Verbose mode, set to output to stdlog. Really outputs to logfile."""
+        ret.append("-vvv")
+
+        """Set job name. Follows convention for ATS in Slurm and LSF schedulers."""
+        test.jobname = f"{np}_{test.serialNumber}{test.namebase[0:50]}{time.strftime('%H%M%S',time.localtime())}"
+        ret.append("--job-name")
+        ret.append(test.jobname)
+        
+        return ret + self.calculateBasicCommandList(test)
+    
+    def canRun(self, test):
+        """
+        Method required for integration with current ATS codebase.
+        Usually, this would check if free resources are available to submit a job,
+        however, that doesn't need to be considered when submitting a Flux job to the queue,
+        so canRun is always true.
+
+        :param test: Required for integration to overwrite method in parent class.
+        """
+        return ''
+    
+    def canRunNow(self, test):
+        """
+        See above. This is maintained for integration with the current ATS codebase.
+        
+        :param test: Required for integration to overwrite method in parent class.
+        """
+        return True
+
+    def periodicReport(self):
+        """
+        Report on current status of tasks and processor availability.
+        Utilizes Flux accessors for resource_list and flux job monitoring capabilities.
+        """
+        # TODO: reconcile ATS's notion of "running" with Flux
+        # ATS says anything that it has submitted to the queue is "running" but with Flux
+        # jobs that have been submitted to the queue may not have necessarily been allocated resources yet
+        
+        if self.running:
+            terminal("CURRENTLY RUNNING %d tests:" % len(self.running),
+                     " ".join([t.name for t in self.running]) )
+        terminal("-"*80)
+
+        ## Flux specific accessors for number of nodes
+        resource_list = flux.resource.list.resource_list(self.fluxHandle).get()
+        procs = resource_list.allocated.nnodes
+        total = resource_list.up.nnodes
+        terminal(f"CURRENTLY UTILIZING {procs} of {total} processors.")
+        terminal("-"*80)
+        
+    def remainingCapacity(self):
+        """Returns the number of free cores in the flux instance."""
+        return flux.resource.list.resource_list(self.fluxHandle).get().free.ncores

--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -16,8 +16,9 @@ import flux
 import flux.job
 
 from ats import terminal
-from ats.tests import AtsTest
 from ats.atsMachines import lcMachines
+from ats.tests import AtsTest
+
 
 class FluxScheduled(lcMachines.LCMachineCore):
     """
@@ -30,11 +31,13 @@ class FluxScheduled(lcMachines.LCMachineCore):
         Sets ceiling on number of nodes and cores in the allocation.
         Defines a persistent handle to use to connect to the broker.
         """
-        # import pdb
-        # pdb.set_trace()
         self.fluxHandle = flux.Flux()
-        self.numNodes = int(flux.resource.list.resource_list(self.fluxHandle).get().up.nnodes)
-        self.maxCores = int(flux.resource.list.resource_list(self.fluxHandle).get().up.ncores)
+        self.numNodes = int(
+            flux.resource.list.resource_list(self.fluxHandle).get().up.nnodes
+        )
+        self.maxCores = int(
+            flux.resource.list.resource_list(self.fluxHandle).get().up.ncores
+        )
         self.coresPerNode = self.maxCores // self.numNodes
         self.numberTestsRunningMax = self.maxCores
 
@@ -42,7 +45,7 @@ class FluxScheduled(lcMachines.LCMachineCore):
         """
         Optparse (soon argparse) parameters from command-line options
         for ATS users. Needed for functionality with .ats files.
-        
+
         :param options: The options available to a user in test.ats files.
         """
         self.exclusive = options.exclusive
@@ -50,18 +53,16 @@ class FluxScheduled(lcMachines.LCMachineCore):
 
     def calculateCommandList(self, test):
         """
-        Generates a list of commands to run a test in ATS on a 
+        Generates a list of commands to run a test in ATS on a
         flux instance.
-        
+
         :param test: the test to be run, of type ATSTest. Defined in /ats/tests.py.
         """
         ret = "flux mini run".split()
-        np = test.options.get('np', 1)
-        nn = test.options.get('nn', 1)
+        np = test.options.get("np", 1)
+        nn = test.options.get("nn", 1)
 
-        # David/Shawn: Time limit compatibility -- how do ATS users specify time limits?
-        # with flux, you have to specify a number, and then m, s, or h, and only one can be specified
-        max_time = test.options.get('timelimit', '29m')
+        max_time = self.timelimit
         ret.append(f"-t{max_time}")
 
         if np > self.coresPerNode:
@@ -69,8 +70,8 @@ class FluxScheduled(lcMachines.LCMachineCore):
         if nn > 0:
             ret.append(f"-N{nn}")
 
-        """Thread subscription interface. Flux does not oversubscribe cores by default."""
-        nt = test.options.get('nt', 1)
+        """Thread subscription - Flux does not oversubscribe cores by default."""
+        nt = test.options.get("nt", 1)
         """
         In order to marry ATS's description of threading with Flux's understanding, Flux will
         request 1 core per thread
@@ -79,14 +80,20 @@ class FluxScheduled(lcMachines.LCMachineCore):
         ret.append(f"-c{nt}")
 
         """GPU scheduling interface"""
-        ngpu = test.options.get('ngpu',0)
+        ngpu = test.options.get("ngpu", 0)
         if ngpu:
             ret.append(f"-g{ngpu}")
 
         """Node-exclusive job scheduling: even if a job does not use the entire resources."""
-        if test.options.get('exclusive', False):
+        if test.options.get("exclusive", False):
             ret.append("--exclusive")
-        
+
+        """
+        CPU affinity enabled settings will go here. These are applicable 
+        to an entire test run, not just to one test.
+        """
+        # ret.append('-o\"cpu-affinity=per-task\"')
+
         """Verbose mode, set to output to stdlog. Really outputs to logfile."""
         ret.append("-vvv")
 
@@ -94,9 +101,8 @@ class FluxScheduled(lcMachines.LCMachineCore):
         test.jobname = f"{np}_{test.serialNumber}{test.namebase[0:50]}{time.strftime('%H%M%S',time.localtime())}"
         ret.append("--job-name")
         ret.append(test.jobname)
-        
         return ret + self.calculateBasicCommandList(test)
-    
+
     def canRun(self, test):
         """
         Method required for integration with current ATS codebase.
@@ -106,12 +112,12 @@ class FluxScheduled(lcMachines.LCMachineCore):
 
         :param test: Required for integration to overwrite method in parent class.
         """
-        return ''
-    
+        return ""
+
     def canRunNow(self, test):
         """
         See above. This is maintained for integration with the current ATS codebase.
-        
+
         :param test: Required for integration to overwrite method in parent class.
         """
         return True
@@ -124,19 +130,21 @@ class FluxScheduled(lcMachines.LCMachineCore):
         # TODO: reconcile ATS's notion of "running" with Flux
         # ATS says anything that it has submitted to the queue is "running" but with Flux
         # jobs that have been submitted to the queue may not have necessarily been allocated resources yet
-        
+
         if self.running:
-            terminal("CURRENTLY RUNNING %d tests:" % len(self.running),
-                     " ".join([t.name for t in self.running]) )
-        terminal("-"*80)
+            terminal(
+                "CURRENTLY RUNNING %d tests:" % len(self.running),
+                " ".join([t.name for t in self.running]),
+            )
+        terminal("-" * 80)
 
         ## Flux specific accessors for number of nodes
         resource_list = flux.resource.list.resource_list(self.fluxHandle).get()
         procs = resource_list.allocated.nnodes
         total = resource_list.up.nnodes
         terminal(f"CURRENTLY UTILIZING {procs} of {total} processors.")
-        terminal("-"*80)
-        
+        terminal("-" * 80)
+
     def remainingCapacity(self):
         """Returns the number of free cores in the flux instance."""
         return flux.resource.list.resource_list(self.fluxHandle).get().free.ncores

--- a/ats/bin/atsflux.py
+++ b/ats/bin/atsflux.py
@@ -1,0 +1,115 @@
+import os
+import sys
+import subprocess as sp
+
+"""
+Wrapper to start ATS with Flux compatibility.
+
+Author: William Hobbs
+        <hobbs17@llnl.gov>
+
+"""
+
+def main():
+    """
+    Wrapper driver for running ATS tests under Flux.
+
+    Available command-line arguments:
+        --nodes= 
+          Specify a number of nodes to use, will default to use 3.
+        --bank=
+          Specify a project bank to charge, will default to use whatever your default bank is.
+        --partition=
+          Specify either the debug or batch partition, will default to use debug.
+    """
+
+    """Check to make sure a valid Flux installation is present on the system."""
+    try: 
+        version = int(sp.check_output(["flux", "-V"]).split()[1].decode("utf-8").split(".")[1])
+        if (version) < 38:
+            sys.exit(
+                f'''Error: this system does not have a current version of Flux installed. 
+                Version 0.{version}.0 is installed but >= 0.38.0 is required. Please update
+                the Flux version or use a different Flux (check which one you're using with `which flux`).
+                '''
+            )
+    except:
+        sys.exit(
+            '''Error: this system does not have a current version of Flux installed. 
+            No version of Flux was found on this system but version >= 0.38.0 required. Please update
+            the Flux version or specify a different Flux installation to use.
+            '''
+        )
+
+    sys_type = os.getenv("SYS_TYPE")
+    slurm_job_id = os.getenv("SLURM_JOB_ID")
+
+    num_nodes = 3
+    for index, arg in enumerate(sys.argv):
+        if (arg.find('nodes') >= 0):
+            (key, val) = arg.split('=',1)
+            if val.startswith('"') and val.endswith('"'):   # strip off possible quotes
+                val = val[1:-1]
+            num_nodes = str(val)
+            print("INFO: atsflux will use %s nodes" % num_nodes)
+            del sys.argv[index]
+
+    partition = "pdebug"
+    for index, arg in enumerate(sys.argv):
+        if (arg.find('partition') >= 0):
+            (key, val) = arg.split('=',1)
+            if val.startswith('"') and val.endswith('"'):   # strip off possible quotes
+                val = val[1:-1]
+            partition = str(val)
+            print("INFO: atsflux will use partition %s" % partition)
+            del sys.argv[index]
+    
+    account = "guests"
+    for index, arg in enumerate(sys.argv):
+        if (arg.find('bank') >= 0):
+            (key, val) = arg.split('=',1)
+            if val.startswith('"') and val.endswith('"'):   # strip off possible quotes
+                val = val[1:-1]
+            account = str(val)
+            print("INFO: atsflux will use bank %s" % account)
+            del sys.argv[index]
+    
+    cmd = []
+
+    if slurm_job_id == None: ## if this is on login node
+        cmd = ["salloc", f"--nodes={num_nodes}", f"--partition={partition}", f"--account={account}", "--time=60"]
+
+    """Get the path to an .ats file and find the test file."""
+    """Find the proper ATS implementation to pass the complete path."""
+    myats = os.path.join(sys.exec_prefix, 'bin', 'ats')
+
+    """The following is copied from atslite1.pyL#28-46"""
+    test_ats_found = False
+    test_ats_file = ""
+    clean_found = False
+    exclusive_found = False
+    nosub_found = False
+
+    for index, arg in enumerate(sys.argv):
+        #print arg
+        if (arg.find('=') >= 0):
+            (key, val) = arg.split('=',1)
+            sys.argv[index] = key + '="' + val + '"'
+        elif (arg.find('exclusive') >= 0):
+            exclusive_found = True
+        elif (arg.find('clean') >= 0):
+            clean_found = True
+        elif arg.endswith('.ats'):
+            test_ats_file = arg
+            if not os.path.exists(test_ats_file):
+                sys.exit("Bummer! Did not find test file %s" % (test_ats_file))
+
+    cmd.extend(["srun", f"-N{num_nodes}", f"-n{num_nodes}", "--pty", "/usr/bin/flux", "start", "-o,-S,log-filename=out"])
+    os.environ['SYS_TYPE'] = "flux00"
+    cmd.extend([myats, test_ats_file])
+    print("Executing: " + " ".join(cmd))
+
+    sp.run(cmd, text=True)
+        
+if __name__ == "__main__":
+    main()

--- a/ats/bin/atsflux.py
+++ b/ats/bin/atsflux.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 import subprocess as sp
@@ -10,12 +11,46 @@ Author: William Hobbs
 
 """
 
+
+def _parse_args() -> argparse.Namespace:
+    """Parse arguments for formatting ATS python files."""
+    parser = argparse.ArgumentParser(description="ATS with Flux!")
+    parser.add_argument(
+        "-N",
+        "--num-nodes",
+        default=3,
+        type=int,
+        help="Number of nodes allocated to atsflux.",
+    )
+    parser.add_argument(
+        "--exclusive",
+        action="store_true",
+        help="Exclusive use of nodes allocated.",
+    )
+    parser.add_argument(
+        "-A",
+        "--account",
+        dest="account",
+        default="guests",
+        type=str,
+        help="Project bank to charge.",
+    )
+    parser.add_argument(
+        "-p",
+        "--partition",
+        default="pdebug",
+        type=str,
+        help="Partition in which to run atsflux jobs.",
+    )
+    return parser.parse_known_args()
+
+
 def main():
     """
     Wrapper driver for running ATS tests under Flux.
 
     Available command-line arguments:
-        --nodes= 
+        --nodes=
           Specify a number of nodes to use, will default to use 3.
         --bank=
           Specify a project bank to charge, will default to use whatever your default bank is.
@@ -24,92 +59,127 @@ def main():
     """
 
     """Check to make sure a valid Flux installation is present on the system."""
-    try: 
-        version = int(sp.check_output(["flux", "-V"]).split()[1].decode("utf-8").split(".")[1])
+    args, extra_args = _parse_args()
+
+    try:
+        version = int(
+            sp.check_output(["flux", "-V"])
+            .split()[1]
+            .decode("utf-8")
+            .split(".")[1]
+        )
         if (version) < 38:
             sys.exit(
-                f'''Error: this system does not have a current version of Flux installed. 
+                f"""Error: this system does not have a current version of Flux installed.
                 Version 0.{version}.0 is installed but >= 0.38.0 is required. Please update
                 the Flux version or use a different Flux (check which one you're using with `which flux`).
-                '''
+                """
             )
-    except:
+    except Exception:
         sys.exit(
-            '''Error: this system does not have a current version of Flux installed. 
+            """Error: this system does not have a current version of Flux installed.
             No version of Flux was found on this system but version >= 0.38.0 required. Please update
             the Flux version or specify a different Flux installation to use.
-            '''
+            """
         )
 
-    sys_type = os.getenv("SYS_TYPE")
+    # TODO: 'sys_type' unused.
+    # sys_type = os.getenv("SYS_TYPE")
     slurm_job_id = os.getenv("SLURM_JOB_ID")
 
-    num_nodes = 3
-    for index, arg in enumerate(sys.argv):
-        if (arg.find('nodes') >= 0):
-            (key, val) = arg.split('=',1)
-            if val.startswith('"') and val.endswith('"'):   # strip off possible quotes
-                val = val[1:-1]
-            num_nodes = str(val)
-            print("INFO: atsflux will use %s nodes" % num_nodes)
-            del sys.argv[index]
-
-    partition = "pdebug"
-    for index, arg in enumerate(sys.argv):
-        if (arg.find('partition') >= 0):
-            (key, val) = arg.split('=',1)
-            if val.startswith('"') and val.endswith('"'):   # strip off possible quotes
-                val = val[1:-1]
-            partition = str(val)
-            print("INFO: atsflux will use partition %s" % partition)
-            del sys.argv[index]
-    
-    account = "guests"
-    for index, arg in enumerate(sys.argv):
-        if (arg.find('bank') >= 0):
-            (key, val) = arg.split('=',1)
-            if val.startswith('"') and val.endswith('"'):   # strip off possible quotes
-                val = val[1:-1]
-            account = str(val)
-            print("INFO: atsflux will use bank %s" % account)
-            del sys.argv[index]
-    
+    # num_nodes = 3
+    # for index, arg in enumerate(sys.argv):
+    #     if arg.find("nodes") >= 0:
+    #         (key, val) = arg.split("=", 1)
+    #         if val.startswith('"') and val.endswith(
+    #             '"'
+    #         ):  # strip off possible quotes
+    #             val = val[1:-1]
+    #         num_nodes = str(val)
+    #         print("INFO: atsflux will use %s nodes" % num_nodes)
+    #         del sys.argv[index]
+    #
+    # partition = "pdebug"
+    # for index, arg in enumerate(sys.argv):
+    #     if arg.find("partition") >= 0:
+    #         (key, val) = arg.split("=", 1)
+    #         if val.startswith('"') and val.endswith(
+    #             '"'
+    #         ):  # strip off possible quotes
+    #             val = val[1:-1]
+    #         partition = str(val)
+    #         print("INFO: atsflux will use partition %s" % partition)
+    #         del sys.argv[index]
+    #
+    # account = "guests"
+    # for index, arg in enumerate(sys.argv):
+    #     if arg.find("bank") >= 0:
+    #         (key, val) = arg.split("=", 1)
+    #         if val.startswith('"') and val.endswith(
+    #             '"'
+    #         ):  # strip off possible quotes
+    #             val = val[1:-1]
+    #         account = str(val)
+    #         print("INFO: atsflux will use bank %s" % account)
+    #         del sys.argv[index]
+    #
     cmd = []
 
-    if slurm_job_id == None: ## if this is on login node
-        cmd = ["salloc", f"--nodes={num_nodes}", f"--partition={partition}", f"--account={account}", "--time=60"]
+    if slurm_job_id == None:  ## if this is on login node
+        cmd = [
+            "salloc",
+            f"--nodes={args.num_nodes}",
+            f"--partition={args.partition}",
+            f"--account={args.account}",
+            "--time=60",
+        ]
 
     """Get the path to an .ats file and find the test file."""
     """Find the proper ATS implementation to pass the complete path."""
-    myats = os.path.join(sys.exec_prefix, 'bin', 'ats')
+    myats = os.path.join(sys.exec_prefix, "bin", "ats")
 
+    # TODO: unused variables below commented out.
     """The following is copied from atslite1.pyL#28-46"""
-    test_ats_found = False
+    # test_ats_found = False
     test_ats_file = ""
-    clean_found = False
-    exclusive_found = False
-    nosub_found = False
+    # clean_found = False
+    # exclusive_found = False
+    # nosub_found = False
 
-    for index, arg in enumerate(sys.argv):
-        #print arg
-        if (arg.find('=') >= 0):
-            (key, val) = arg.split('=',1)
-            sys.argv[index] = key + '="' + val + '"'
-        elif (arg.find('exclusive') >= 0):
-            exclusive_found = True
-        elif (arg.find('clean') >= 0):
-            clean_found = True
-        elif arg.endswith('.ats'):
-            test_ats_file = arg
-            if not os.path.exists(test_ats_file):
-                sys.exit("Bummer! Did not find test file %s" % (test_ats_file))
+    # TODO: test_ats_file should be found in extra_args
+    test_ats_file = extra_args
 
-    cmd.extend(["srun", f"-N{num_nodes}", f"-n{num_nodes}", "--pty", "/usr/bin/flux", "start", "-o,-S,log-filename=out"])
-    os.environ['SYS_TYPE'] = "flux00"
+    # for index, arg in enumerate(sys.argv):
+        # print arg
+        # if arg.find("=") >= 0:
+        #     (key, val) = arg.split("=", 1)
+        #     sys.argv[index] = key + '="' + val + '"'
+        # elif arg.find("exclusive") >= 0:
+        #     exclusive_found = True
+        # elif arg.find("clean") >= 0:
+        #     clean_found = True
+        # elif arg.endswith(".ats"):
+        #     test_ats_file = arg
+        #     if not os.path.exists(test_ats_file):
+        #         sys.exit("Bummer! Did not find test file %s" % (test_ats_file))
+
+    cmd.extend(
+        [
+            "srun",
+            f"-N{args.num_nodes}",
+            f"-n{args.num_tasks}",
+            "--pty",
+            "/usr/bin/flux",
+            "start",
+            "-o,-S,log-filename=out",
+        ]
+    )
+    os.environ["SYS_TYPE"] = "flux00"
     cmd.extend([myats, test_ats_file])
     print("Executing: " + " ".join(cmd))
 
     sp.run(cmd, text=True)
-        
+
+
 if __name__ == "__main__":
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,4 @@ console_scripts =
     ats3 = ats.bin._ats3:main
     atslite1 = ats.bin.atslite1:main
     atslite3 = ats.bin.atslite3:main
+    atsflux = ats.bin.atsflux:main


### PR DESCRIPTION
Per our discussion today with @dawson6, @davidbloss, and @jameshcorbett, this PR is opened to test the compatibility of a work-in-progress Flux executor and monitor the progress of expanding ATS compatibility for Flux.

Currently, the Flux executor has option compatibility for:
- number of cores
- number of nodes
- exclusivity within an allocation
- verbose output of Flux key value store

To test this on Ruby (or another slurm-runnning LC cluster), install ATS in a virtual environment and request an allocation from slurm:
```salloc -N 3 -p pdebug -A cbronze -t 60```

And then start a flux instance using `srun`:
```srun -N 3 --pty flux start```