### PR TITLE
add black and isort formatters

### DIFF
--- a/ats/bin/atsformat.py
+++ b/ats/bin/atsformat.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse arguments for formatting ATS python files."""
+    parser = argparse.ArgumentParser(description="Format ATS python files.")
+    parser.add_argument(
+        "-c",
+        "--check",
+        action="store_true",
+        help="Check if isort or black would format ATS' code",
+    )
+    parser.add_argument(
+        "path",
+        nargs="+",
+        type=Path,
+        help="File(s) or directory to parse recursively.",
+    )
+    return parser.parse_args()
+
+
+def unformat_ATS_headers(ats_file) -> None:
+    """Undo formatting on ATS headers. Keep `#ATS:` and `#BATS:` as is."""
+    with open(ats_file) as _file:
+        file_contents = _file.read()
+
+    formatted_contents = file_contents.replace("# ATS:", "#ATS:").replace(
+        "# BATS:", "#BATS:"
+    )
+
+    with open(ats_file, "w") as _file:
+        _file.write(formatted_contents)
+
+
+def main() -> None:
+    """ATS files formatting script using various formatters."""
+    args = _parse_args()
+
+    # Favor formatters found by Python over ones found in system $PATH
+    BLACK_CMD = [sys.executable, "-m", "black"]
+    ISORT_CMD = [sys.executable, "-m", "isort"]
+    BLACK_OPTIONS = ["--check"] if args.check else []
+    ISORT_OPTIONS = [
+        "--check" if args.check else "--apply",
+        "--profile",
+        "black",
+    ]
+
+    print("ATS: Running Black formatter...")
+    subprocess.run(BLACK_CMD + BLACK_OPTIONS + args.path)
+    print("ATS: Black formatter done.\n")
+
+    print("ATS: Running isort formatter...")
+    subprocess.run(ISORT_CMD + ISORT_OPTIONS + args.path)
+    print("ATS: isort formatter done.")
+
+    for machine_file in Path("ats", "atsMachines").glob("*.py"):
+        unformat_ATS_headers(machine_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,18 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 80
+target-version = ['py38']
+extend-exclude = '''
+/(
+  # Use ats/bin/atsformat to format ats/atsMachines
+  | ats/atsMachines/
+  | ats/bin/
+  | scripts/
+)/
+'''
+
+[tool.isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,15 @@ install_requires=
 packages = find:
 python_requires = >=3.8
 
+[options.extras_require]
+dev=
+  black>=22.6
+  isort>=5.10
+
 [options.entry_points]
 console_scripts =
     ats = ats.bin._ats:main
     ats3 = ats.bin._ats3:main
+    atsformat = ats.bin.atsformat:main
     atslite1 = ats.bin.atslite1:main
     atslite3 = ats.bin.atslite3:main


### PR DESCRIPTION
Introducing the `atsformat` command. `atsformat` uses `black` and `isort` to format python files. One initial setback with `black` was its insistence on converting `#ATS:` to `# ATS:` that breaks the code. So `atsformat` lets `black` do this and later reverts `# ATS:` back to `#ATS:` - same for `#BATS:`.

By default, `black` and `isort` are not installed but developers can include these during the ATS installation \
by adding `"[dev]"` like this: `pip install <path to ATS>"[dev]"`