### PR TITLE
testsuite: add unit testing for Flux code in ATS

### DIFF
--- a/test/unit/flux/t0001-flux.py
+++ b/test/unit/flux/t0001-flux.py
@@ -1,0 +1,36 @@
+import subprocess
+import unittest
+
+import ats.management
+import ats.configuration
+from ats.management import test
+from ats.atsMachines.fluxScheduled import FluxScheduled
+
+class Foo:
+    def __init__(self):
+        self.maxCores = 8
+        self.options = []
+            
+    def calculateBasicCommandList(self):
+        return ["./a.out", "5", "20"]
+
+class TestFluxScheduled(unittest.TestCase):        
+    def test_valid_jobspec(self):
+        # ats.management.AtsManager()
+        test1 = test("./a.out", "5 5", nt=4, np=1, nn=1)
+        cmd = FluxScheduled.calculateCommandList(Foo(), test1)
+        # cmd.append("--dry")
+        return_code = subprocess.run(cmd).returncode
+        self.assertGreater(return_code, -1) ## a 0 or positive return code indicates test passes
+
+    def test_invalid_jobspec(self):
+        ats.management.AtsManager.init(Foo())
+        test1 = test("./a.out", "5 5", nn=0, ngpu=0)
+        cmd = FluxScheduled.calculateCommandList(Foo(), test1)
+        # cmd.append("--dry")
+        return_code = subprocess.run(cmd).returncode
+        self.assertLess(return_code, 0) ## any negative return value indicates that this fails
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR, unfinished, is being put up by popular request.

Some refactoring of ATS might be required to fully support unit testing, but this is a first pass at it. 

The tests (failing) can be run with `python3 t0001-flux.py` and require both an ATS installation and running flux session. We ultimately decided to go with an implementation of regression testing for Flux on Quartz instead.

The tests were supposed to test whether fluxScheduled.py is able to construct valid jobspecs from valid ATS tests, and vice versa.