### PR TITLE
testsuite: add flux integration testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,8 @@ default:
     - python3 -m virtualenv --python=python3.8 TEST_VENV
     - source TEST_VENV/bin/activate
     - pip install .
+    - pip install pyyaml
+    - pip install cffi
 
 .hello_ATS:
   extends: .install_ATS
@@ -27,8 +29,27 @@ default:
       .gitlab/assert_ats_results.awk -v PASSED=22 FAILED=12 SKIPPED=10
       test/HelloATS/$SYS_TYPE*.logs/ats.log
 
+.hello_Flux:
+  extends: .install_ATS
+  stage: test
+  variables:
+    BANK: cbronze
+  script:
+    - cd test/HelloATS
+    - mpicc hello_ats.c
+    - python3 create_test_ats.py
+    - atsflux --account=${BANK} test.ats
+    - cd $OLDPWD
+    - >
+      .gitlab/assert_ats_results.awk -v PASSED=22 FAILED=12 SKIPPED=10
+      test/HelloATS/flux00*.logs/ats.log
+    - rm -rf *.logs
+
 hello_ATS_TOSS:
   extends: [.hello_ATS, .run_quartz_shell]
+
+hello_flux_TOSS:
+  extends: [.hello_Flux, .run_quartz_shell]
 
 #hello_ATS_BLUEOS:
 #  extends: [.hello_ATS, .run_lassen_shell]


### PR DESCRIPTION
Problem: Current GitLab CI/CD tests do not test the  binary.

Solution: Add testing for ATS's Flux code.

This should work under @davidbloss's credentials on Quartz, but I saw that @dawson6 you have a different bank, so if it's running under your account I may need to make a slight change. Also, when I tested in my GitLab fork the Kripke tests failed, but I assumed that didn't have anything to do with this commit.