### PR TITLE
Add recent fixes from Python3 branch into main branch.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,46 @@
 # ATS Release Notes
 
+## 7.0.Next
+
+    Update sleepBeforeRun option.
+    Renamed from sleepBeforeSrun.
+    Still honor sleepBeforeSrun, simply map
+    to sleepBeforeRun.
+    Change value given to this option from an int to a float.
+    
+    Add tossrun for VIP project usage.
+
+    Fix globalPostrunScript and globalPrerunScript processing.
+    
+    Strip quotes which are somehow addedd to the string in Python3
+    Otherwise we can not verify the file exists or execute it.
+    
+    Default ruby machine type to slurm56
+
+    For slurm:
+    Account for slurm version such as 21.08.8-2
+    
+    Added --useMinNodes for toss (slurm)
+    
+    If --useMinNodes specified, then within an allocation
+    specify
+    
+        srun_nodes="--nodes=%i-%i" % (minNodes, minNodes)
+    
+    when starting the job, where minNodes is the minimum
+    number of nodes needed for the requested number of MPI
+    processes.   This is experimental at this point,
+    and may lead to hangs or lower throughput.
+
+    For blueos:
+    Add smpi options to ats command line
+    
+    Either one of these may be used to disable the --smpiargs="-gpu" option.
+    
+    --smpi_off
+    --smpi_show
+
+
 ## 7.0.106
 
 * Updating version to 7.0.106 for alpha testing.

--- a/ats/atsMachines/slurmProcessorScheduled.py
+++ b/ats/atsMachines/slurmProcessorScheduled.py
@@ -6,13 +6,14 @@
 #ATS:slurm24                 SELF SlurmProcessorScheduled 24
 #ATS:slurm32                 SELF SlurmProcessorScheduled 32
 #ATS:slurm36                 SELF SlurmProcessorScheduled 36
+#ATS:slurm56                 SELF SlurmProcessorScheduled 56
 #ATS:toss_3_x86_64_ib        SELF SlurmProcessorScheduled 36
 #ATS:toss_3_x86_64           SELF SlurmProcessorScheduled 36
 #ATS:toss_4_x86_64_ib_cray   SELF SlurmProcessorScheduled 64
 
 import inspect
 import math
-import sys, os, time, subprocess
+import re, sys, os, time, subprocess
 
 from ats import machines, debug, atsut
 from ats import log, terminal
@@ -46,7 +47,7 @@ class SlurmProcessorScheduled(lcMachines.LCMachineCore):
         tarray=tstr.split() 
         SlurmProcessorScheduled.slurm_version_str=tarray[1]
         log('SLURM VERSION STRING', SlurmProcessorScheduled.slurm_version_str)
-        tarray=SlurmProcessorScheduled.slurm_version_str.split('.')
+        tarray=re.split('[\.\-]',SlurmProcessorScheduled.slurm_version_str);
         SlurmProcessorScheduled.slurm_version_int=(int(tarray[0]) * 1000) + (int(tarray[1]) * 100) + (int(tarray[2]))
         log('SLURM VERSION NUMBER', SlurmProcessorScheduled.slurm_version_int)
 
@@ -202,6 +203,7 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
         self.salloc    = options.salloc
         self.toss_nn   = options.toss_nn
         self.strict_nn = options.strict_nn
+        self.useMinNodes = options.useMinNodes
         self.timelimit = options.timelimit
 
         if SlurmProcessorScheduled.debugClass:
@@ -385,6 +387,9 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
                 srun_nodes="--nodes=%i-%i" % (num_nodes, self.numNodes)
             else:
                 srun_nodes="--nodes=%i-%i" % (num_nodes, num_nodes)
+
+        elif self.useMinNodes == True:
+            srun_nodes="--nodes=%i-%i" % (minNodes, minNodes)
 
         # ----------------------------------------------------------------------------------------------------------------------------
         # 

--- a/ats/machines.py
+++ b/ats/machines.py
@@ -270,7 +270,12 @@ call noteEnd for machine-specific part.
             print("DEBUG MachineCore.testEnded invoked cwd= %s " % (os.getcwd()))
 
         globalPostrunScript_outname = test.globalPostrunScript_outname
+
         globalPostrunScript         = test.options.get('globalPostrunScript', None)
+        # Strip quotes which are somehow added to the string in Python3
+        # Otherwise we can't verify the file exists or execute it.
+        globalPostrunScript=globalPostrunScript.replace('"', '')
+
         #verbose                     = test.options.get('verbose', False)
         verbose                     = configuration.options.debug
 
@@ -520,7 +525,12 @@ The subprocess part of launch. Also the part that might fail.
         # See if user specified a file to use as stdin to the test problem.
         stdin_file                  = test.options.get('stdin', None)
         globalPrerunScript_outname  = test.globalPrerunScript_outname
+
         globalPrerunScript          = test.options.get('globalPrerunScript', None)
+        # Strip quotes which are somehow added to the string in Python3
+        # Otherwise we can't verify the file exists or execute it.
+        globalPrerunScript=globalPrerunScript.replace('"', '')
+
         #verbose                     = test.options.get('verbose', False)
         verbose                     = configuration.options.debug
 
@@ -572,20 +582,20 @@ The subprocess part of launch. Also the part that might fail.
             # Starting jobs too fast confuses slurm and MPI.  Short wait between each job submittal
             # This showsd up with my atsHello test program
             # Default sleep is 1 on toss, 0 on other systems, may be set by user on command line
+            #
             # 2016-12-02
             # Default sleep is now 0 on all systems.
-            if hasattr(test, 'runningWithinSalloc'):
-                if configuration.options.sleepBeforeSrun > 0:
+
+            # 2021-Sep-21  
+            # Per project request.  If nosrun is on, do not sleep (as we are not using MPI in that scenario)
+            #
+            nosrun  = test.options.get('nosrun', False)
+            if nosrun == False:
+                if configuration.options.sleepBeforeRun > 0.0:
                     if MachineCore.printSleepBeforeSrunNotice:
                         MachineCore.printSleepBeforeSrunNotice = False
-                        print("ATS Info: MachineCore._launch Will sleep %d seconds before each srun " % configuration.options.sleepBeforeSrun)
-                    time.sleep(configuration.options.sleepBeforeSrun)
-            else:
-                if configuration.options.sleepBeforeSrun > 0:
-                    if MachineCore.printSleepBeforeSrunNotice:
-                        MachineCore.printSleepBeforeSrunNotice = False
-                        print("ATS Info: MachineCore._launch Will sleep %d seconds before each srun " % configuration.options.sleepBeforeSrun)
-                    time.sleep(configuration.options.sleepBeforeSrun)
+                        print("ATS Info: MachineCore._launch Will sleep %f seconds before each srun " % configuration.options.sleepBeforeRun)
+                    time.sleep(configuration.options.sleepBeforeRun)
 
 
             if testStdout == 'file':


### PR DESCRIPTION
Update sleepBeforeRun option.
Renamed from sleepBeforeSrun.
Still honor sleepBeforeSrun, simply map
to sleepBeforeRun.
Change value given to this option from an int to a float.

Add tossrun for VIP project usage.

Fix globalPostrunScript and globalPrerunScript processing.

Strip quotes which are somehow addedd to the string in Python3
Otherwise we can't verify the file exists or execute it.

Default ruby machine type to slurm56

For slurm:
Account for slurm version such as 21.08.8-2

Added --useMinNodes for toss (slurm)

If --useMinNodes specified, then within an allocation
specify

srun_nodes="--nodes=%i-%i" % (minNodes, minNodes)

when starting the job, where minNodes is the minimum
number of nodes needed for the requested number of MPI
processes.   This is experimental at this point,
and may lead to hangs or lower throughput.

For blueos:
Add smpi options to ats command line

Either one of these may be used to disable the --smpiargs="-gpu" option.

--smpi_off
--smpi_show