### PR TITLE
Machines as plugins

### DIFF
--- a/docs/source/ats.rst
+++ b/docs/source/ats.rst
@@ -1,10 +1,9 @@
-##################
-Reference Material
-##################
+====================
+ Reference Material
+====================
 
-****************************
 Test Selection and Execution
-****************************
+============================
 
 Tests are defined in ATS input using two commands, ``test`` and its little 
 brother, ``testif``. However, not every test that gets defined is necessarily
@@ -18,7 +17,7 @@ set of facilities involving filters, command-line options, and arguments to
 executions. 
 
 ATS Execution and Command-line Options
-======================================
+--------------------------------------
 
 .. index:: input file names
 
@@ -30,7 +29,7 @@ using its name, then with a ``.ats`` extension, and then with a ``.py`` extensio
    pair:execution;ATS
 
 Unix or Mac
------------
+~~~~~~~~~~~
 
 To start ATS on a Unix system or Mac, execute this line in a terminal 
 window::
@@ -47,7 +46,7 @@ particular executables. Please consult with the owner of your local ATS
 installation, and the owners of any custom ATS drivers you may be using.
 
 Windows
--------
+~~~~~~~
 Execution on windows can be done in the same way from a command window, but
 can be made more convenient by defining a ``.bat`` file, such as::
 
@@ -57,7 +56,7 @@ These instructions need improvement as the first Windows users determine
 the right way to do this.
 
 Command-line Options
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 .. index::
    pair:command-line options;ATS
@@ -178,7 +177,7 @@ ATS installation.
    Show program's version number and exit.
 
 Basic Operations
-================
+----------------
 
 The goal of ATS is to execute a series of test problems.  It does this by 
 reading input files written in the Python language, with some predefined ATS
@@ -198,7 +197,7 @@ problem input to contain definitions of how they are to be run when run by
 ATS.
 
 Retrying Failed Tests
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 If any tests fail or are not completed, a "continuation" file is written and 
 a message issued in the summary section giving the name of the file. 
@@ -229,7 +228,7 @@ believe you have corrected all errors.
 .. index:: post-processing file
 
 Results Facility
-----------------
+~~~~~~~~~~~~~~~~
 
 Each run creates an ``atsr.py`` file in the log directory. This file, if
 run under Python, creates one variable named "state", which is an
@@ -311,12 +310,11 @@ directory.
     
 .. _Input:
 
-*****************
 Controlling Input
-*****************
+=================
 
 File Sourcing
-=============
+-------------
 
 .. function:: source(*paths, **vocabulary)
 
@@ -369,7 +367,7 @@ suit your input convention, using the second argument to ``source``.
    triple:onCollected;input;customization
 
 Examining and prioritizing tests
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After collection of the tests the user may wish to examine or alter the
 tests before they are executed.  This is done by registering one or more 
@@ -427,7 +425,7 @@ final absolute value.
    single: introspection
 
 Using Introspection
-===================
+-------------------
 
 .. index::
    triple: ``#ATS:``; input; introspection
@@ -468,7 +466,7 @@ need to be ATS commands; they can be any Python code.  They can also
 include log commands, source other files, etc.
 
 Changing the introspection convention
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. index::
    pair:introspection;changing comment convention
@@ -504,7 +502,7 @@ define after you declare it. For example::
 .. _group_statement:
 
 Grouping
-========
+--------
 
 If you have a test that creates some files for postprocessing, you can group that 
 test with the related ones.
@@ -547,7 +545,7 @@ one test skip another. To achieve dependency, use the 'testif' facility.
    single:preventing conflicts
 
 Wait
-====
+----
 
 It is certainly possible to make two tests that appear to be independent but which 
 cannot in fact run simultaneously. ATS prevents many cases of this due to its reluctance
@@ -578,7 +576,7 @@ postprocessors that have been registered using the `onExit` facility described
 later.
 
 Example
--------
+~~~~~~~
 
 Suppose we have this test file "waitforit.ats"::
 
@@ -631,9 +629,8 @@ not affected by the wait statement in the sourced file.  In that file
 the first two tests are waiting for the first two, and the third waits for
 the first four.
 
-***************
 Executing Tests
-***************
+===============
 
 ATS attempts to execute as many tests as it can at the same time in order to keep
 the computational resources it has been given busy, subject to respecting the 
@@ -643,7 +640,7 @@ The following sections describe this process.
 .. _scheduling:
 
 Scheduling
-==========
+----------
 
 .. index::
    pair:priority;scheduling
@@ -714,7 +711,7 @@ until they are all complete.
 .. index:: --verbose
 
 Progress Reports
-================
+----------------
 
 When a test starts this fact is shown on the terminal output. You can use the command
 option ``--verbose`` to cause test completions and other additional events to be reported
@@ -732,7 +729,7 @@ Every minute ATS issues a report on its progress to the terminal only.
    pair: test option; keep
 
 Output Files
-============
+------------
 
 The standard output and standard error of a test are written into 
 files in the directory where the logs are written.  These files are (usually) 
@@ -757,22 +754,21 @@ keep=True or check=True.
     pair: RUNNING; status
 
 Interrupting a Run
-==================
+------------------
 
 A control-C interrupt will terminate the program and all the tests it
 is running. Any test started but still not finished will be reported
 in RUNNING status.
 
-****************************
 Creating and Selecting Tests
-****************************
+============================
 
 .. index:: test creation
 
 .. _testFunction:
 
 Creating Tests
-==============
+--------------
 
 .. function:: test(*args, **options)
 
@@ -855,7 +851,7 @@ Explanation: This works because the test call returned a test
 object, ``t``. 
 
 Expecting Failure
------------------
+~~~~~~~~~~~~~~~~~
 
 .. index:: ~ operator
 
@@ -878,7 +874,7 @@ It is pointless to have a dependent of a test that is not expected to PASS.
 It will be SKIPPED.
 
 Test Options
-============
+------------
 
 .. index:: test option overview
 
@@ -896,7 +892,7 @@ There are five lifetimes of option specification:
  * per test (using the options portion of the test command).
 
 Reserved option names
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 .. index::
    single: test options
@@ -1035,7 +1031,7 @@ hideOutput
    If true, do not print magic output lines in the log.
 
 Extra Arguments On The Executable
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. index:: executable
 
@@ -1059,7 +1055,7 @@ you must use an extra quotation level::
     test(executable=my_application, clas = "\"print '3+4'\"")
 
 Filters
-=======
+-------
 
 .. index:: filters
 
@@ -1105,7 +1101,7 @@ would pass the filter 'x==7' but not pass the filter 'x==5' nor the filter
 'y==7' (because the symbol y is not defined by the test).
 
 Additional ATS Vocabulary
-=========================
+-------------------------
 
 ATS input is written in a expanded dialect of Python. That dialect
 contains the following facilities.
@@ -1113,7 +1109,7 @@ contains the following facilities.
 .. index:: vocabulary
 
 Debugging and logging
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 .. index::
    pair:--debug;command line options
@@ -1180,7 +1176,7 @@ please.
 It is not possible to log a partial line.
 
 Manipulating Test Options
-=========================
+-------------------------
 
 .. index::
    pair: test options; manipulating
@@ -1309,7 +1305,7 @@ Despite the power available here, we recommend you don't get too cute about it.
 The main thing is for it to be clear what is happening.
 
 Customization
-=============
+-------------
 
 .. _Customization:
 
@@ -1318,7 +1314,7 @@ These include defining your own postprocessor, main program, and
 application-specific input language extensions.
 
 Using Levels
-============
+------------
 
 .. index:: levels
 
@@ -1353,7 +1349,7 @@ depends on test5, which has level 20, so it will not be run even though it has
 level 10.
 
 The Test Class
-==============
+--------------
 
 When a test is created by the test or testif command, a test object representing
 it is added to manager.testlist.  This object is an instance of a class named
@@ -1490,7 +1486,7 @@ The class ``AtsTest`` is available to users as ``ats.AtsTest``.
 There are other methods that are not intended for end users.
 
 Test Statuses
--------------
+~~~~~~~~~~~~~
 
 There are eleven status values that a test can have. This value is stored in the 
 test's attribute ``status``. Collectively this set of a statuses is in the
@@ -1559,7 +1555,7 @@ HALTED (HALT)
 
 
 Postprocessing
-==============
+--------------
 
 .. index:: postprocessing
 
@@ -1590,7 +1586,7 @@ of this kind using the ``state`` variable as the ``manager`` argument, rather th
 doing it as an ``onExit`` routine.
 
 Test Suite Strategies
-=====================
+---------------------
 
 .. index::
    pair: test suite; organization
@@ -1662,9 +1658,8 @@ different.
 The extended example in Examples/Andyroid gives you many more ideas about how 
 to use ATS.
 
-***************************
 Porting and Custom Machines
-***************************
+===========================
 
 .. index:: porting to new machine types
 
@@ -1754,8 +1749,45 @@ is the name of a directory below your Python installation root where the
 machine files are found by ATS.  The scripts line can be omitted if you 
 do not want to install your own driver. 
 
+Installing Machines as Plugins
+------------------------------
+
+As an alternative to the ``data_files`` approach you can register custom machines
+with ATS using setup tools' entry points plugin mechanism.  This may be convenient
+if you are building more customized ATS wrappers that are themselves packages, but
+can also be used on standalone plugin packages. In this install method, ATS will look for
+these in the group ``"ats.machines"``.  This entry point name space is required for ATS
+to find your machine plugin.  The example below shows how to set this up with a
+``pyproject.toml`` build system using setuptools::
+
+  ...
+  
+  [build-system]
+  requires = ["setuptools", "wheel"]
+  build-backend = "setuptools.build_meta"
+
+  ...
+
+  [project.entry-points."ats.machines"]
+  custom_slurm_proc_sched = "mywrapper.atsMachines.myAtsSlurmProcessorScheduled:MyAtsSlurmProcessorScheduled"
+
+This shows adding a ``custom_slurm_proc_sched`` machine that's defined in the parent
+wrapper ``mywrapper``'s atsMachines submodule, where the ``MyAtsSlurmProcessorScheduled``
+class is defined in ``myAtsSlurmProcessorScheduled.py``. This makes the machine name
+``custom_slurm_proc_sched`` available to ats to use to instatiate a new machine.  With
+this case you can either write whole new machines from scratch, or inherit from one
+of the default machines to change it's behavior.  For more details see the setuptools
+documentations, which also includes more how-to's for ``setup.py`` and ``setup.cfg`` based
+packages.
+
+Note one major difference with this method currently: the default machine config is not
+read from the ``#ATS:name module class npMax`` comment.  The name, module and class gets
+read in from the plugin info, but the ``npMax`` field is not set.  It defaults to -1
+in this case; the current convention is to use env vars to override it inside the machines,
+so be sure and set those accordingly when configuring your custom machines.
+   
 Adding Test Options Via Machine
-===============================
+-------------------------------
 
 In a customized machine, the ``examineOptions`` routine can add entries to 
 a dictionary, ``options.testDefaults``. These will be default option values for each
@@ -1774,7 +1806,7 @@ each test's option ``nt``; but it would always have one, and hence it could be
 used in filters.
 
 Customizing the Scheduler
-=========================
+-------------------------
 
 The scheduler class StandardScheduler is defined in module ``schedulers``. It
 handles issues such as priorities, and enforcing rules for the ``group()`` 
@@ -1796,9 +1828,8 @@ a list of the jobs currently running.  The ``periodicReport`` in the
 scheduler does the basic report once a minute; a machine can call this and 
 then add more.
 
-**************
 The ats Module
-**************
+==============
 
 The ``ats`` module can be imported in custom drivers and postprocessors.
 Resources available in it are all imported from internal modules.
@@ -1849,12 +1880,11 @@ These are documented further in the Appendix.
 .. index:: 
    pair: StandardScheduler;customizing
 
-**********************
 Using A Batch Facility
-**********************
+======================
 
 General Information
-===================
+-------------------
 
 .. index:: batch
 
@@ -1886,7 +1916,7 @@ For the LC system in particular,
   the tests.
 
 Running Entirely In Batch
-=========================   
+-------------------------
 
 Submitting a lot of single batch jobs may overwhelm some batch systems.
 In that case it may be preferable to submit just one big batch job.
@@ -1919,16 +1949,15 @@ The command-line options ``--numNodes=4 --useSrunStep`` are not a part of
 standard ATS. In this case, the ATS machine type ``chaos_4_x86_64_ib`` has been 
 defined in a custom machine file, and custom machine files can add command-line options.
  
-*************
 More Examples
-*************
+=============
 
 .. index::examples
 
 .. index::introspection
 
 Introspection
-=============
+-------------
 
 ::
 
@@ -1958,7 +1987,7 @@ files that get read. If this were a ``stick``, it wouldn't apply inside those
 other files.
 
 Test Control
-============
+------------
 
 .. index:: filters
 
@@ -2050,7 +2079,7 @@ Finally,
 will test both myTestA and myTestB.
 
 Resources For Learning ATS
-==========================
+--------------------------
 
 The `Examples` directory in the distribution contains the sources that
 accompany the Andyroid Tutorial, including some sample customizations.
@@ -2062,7 +2091,7 @@ At your particular location you may find other directories that define
 machines and batch systems for your local computer center.
 
 Quick Recipes
-=============
+-------------
 
 * To run only the batch tests::
 


### PR DESCRIPTION
This PR enables finding machines installed using setuptools' [entry points plugin](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins) mechanism: 

Sample toml file in a project with these machines (note project/package name is a dummy and not real):

``` toml
[project]
name = "myats"
version = "0.0.1"
description = "MyATS Wrapper"
dependencies = [
    "ats",
]
requires-python = ">=3.8"

[build-system]
requires = ["setuptools", "wheel"]
build-backend = "setuptools.build_meta"

[tool.setuptools.packages.find]
where = ["."]
include = ["myats"]

[project.scripts]
myats = "myats.myats:main"  # install console script to launch myats wrapper/driver

[project.entry-points."ats.machines"]
my_slurm_proc_sched = "myats.myAtsMachines.myAtsSlurmProcessorScheduled:MyAtsSlurmProcessorScheduled"
```
This will register the MyAtsSlurmProcessorScheduled custom machine as a plugin names 'my_slurm_proc_sched', which are found within importlib.metadata.entry_points().  These get installed into known groups that the machine import knows to look for, which is currently called 'ats.machines'.

Note, this does not address the separate config issue, using -1 as the default for the constructor of the actual base machine object inherited from.  Our wrapper overrides this in our config anyway so this default works fine, but longer term I think this would pair quite well with a separate config as input type approach rather than having such cluster specific config/init settings baked into the machine source files using that custom header comment; as a bonus there'd be much less code churn to adapt to new clusters. 

Jeremy