### PR TITLE
Temporarily revert custom ast parser to old exec machinery

### DIFF
--- a/ats/management.py
+++ b/ats/management.py
@@ -238,9 +238,10 @@ Attributes:
                     log(line, echo=False)
             os.chdir(directory)
             try:
-                parser = AtsCodeParser(code)
-                for code_segment in parser.get_code_iterator():
-                    exec(code_segment, testenv)
+                exec(code, testenv)
+                # parser = AtsCodeParser(code)
+                # for code_segment in parser.get_code_iterator():
+                #     exec(code_segment, testenv)
                 if debug():
                     log('Finished ', t1, datestamp())
             except KeyboardInterrupt:
@@ -255,18 +256,23 @@ Attributes:
             log.indent()
             os.chdir(directory)
             try:
-                parser = AtsFileParser(t1)
-                for code_segment in parser.get_code_iterator():
-                    exec(code_segment, testenv)
-                if debug(): log('Finished ', t1, datestamp())
+                exec(compile(open(t1, "rb").read(), t1, 'exec'), testenv)
+                # parser = AtsFileParser(t1)
+                # for code_segment in parser.get_code_iterator():
+                #     exec(code_segment, testenv)
+                if debug():
+                    log('Finished ', t1, datestamp())
+
                 result = 1
             except KeyboardInterrupt:
                 raise
             except Exception as details:
                 self.badlist.append(t1)
                 log('Error in input file', t1, ':', echo=True)
-                log(details, echo=True)
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                log(traceback.print_exception(exc_type, exc_value, exc_traceback), echo=True)
                 log('------------------------------------------', echo=True)
+
             log.dedent()
         AtsTest.endGroup()
         unstick()


### PR DESCRIPTION
PR to address the issue in Discussion #101.  This temporarily reverts to the previous exec(test) and exec(compile( test )) mechanisms for ingesting the tests defined in the ats files. 