### PR TITLE
Adding jsrun_np_max option

### DIFF
--- a/ats/atsMachines/lsf_asq.py
+++ b/ats/atsMachines/lsf_asq.py
@@ -159,6 +159,7 @@ class lsfMachine (machines.Machine):
         self.ompProcBind      = options.ompProcBind
         self.ngpu             = options.blueos_ngpu
         self.blueos_np        = options.blueos_np
+        self.blueos_np_max    = options.blueos_np_max
         self.cpusPerTask      = options.cpusPerTask
         self.timelimit        = options.timelimit
         self.mpi_um           = options.mpi_um
@@ -307,6 +308,7 @@ class lsfMachine (machines.Machine):
         commandList = self.calculateBasicCommandList(test)
         test.jobname         = "t%d_%d%s%s" % (np, test.serialNumber, test.namebase[0:50], timeNow)
         test.blueos_np       = self.blueos_np
+        test.blueos_np_max   = self.blueos_np_max
         test.cpusPerTask     = self.cpusPerTask
         test.jsrun_omp       = self.jsrun_omp
         test.jsrun_bind      = self.jsrun_bind
@@ -323,10 +325,16 @@ class lsfMachine (machines.Machine):
             print("JSRUN 020 DEBUG lsf_asq test.jsrun_bind         =  %s " % test.jsrun_bind)
             print("JSRUN 020 DEBUG lsf_asq test.lrun_jsrun_args    =  %s " % test.lrun_jsrun_args)
 
-        # Allow the ats command line --blueos_np option will over-ride the test specific np option
+        # Command line --blueos_np option will over-ride the test specific np option
         if test.blueos_np > 0:
             test.np = test.blueos_np
             np = test.blueos_np
+
+        # Command line --blueos_np_max option will over-ride the test specific np option if
+        # the test specific option is greater than the command line option
+        if test.blueos_np_max > 0 and  test.np > test.blueos_np_max:
+            test.np = test.blueos_np_max
+            np = test.blueos_np_max
 
         lsfMachine.set_nt_cpus_per_task_num_nodes(self, test)
         num_nodes = test.num_nodes

--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -100,6 +100,7 @@ def addOptions(parser):
         exclusive=True,
         blueos_ngpu=0,
         blueos_np=-1,
+        blueos_np_max=-1,
         cuttime=None,
     )
 

--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -180,6 +180,10 @@ def add_blueos_only_options(parser):
                       settings of np (number of processors).  Useful for GPU
                       tests where the 4 MPI and 4 GPU devices are a common
                       testing scenario''')
+    parser.add_option('--lsrun_np_max', dest='blueos_np_max', type='int',
+                      help='''Blueos option: Over-rides test specific settings
+                      of np (number of processors) if the test is set greater
+                      than the value provided.''')
     parser.add_option('--ompDisplayEnv', action='store_true',
                       help='''Blueos option: Set OMP_DISPLAY_ENV=True to see
                       detailed OMP settings at run time''')
@@ -195,9 +199,13 @@ def add_blueos_only_options(parser):
                       OMP built codes.''')
     parser.add_option('--jsrun_np', dest='blueos_np', type='int',
                       help='''Blueos option: Over-rides test specific settings
-                      of np (number of processors).  Useful for GPU tests where
+                      of np (number of processors). Useful for GPU tests where
                       the 4 MPI and 4 GPU devices are a common testing
                       scenario''')
+    parser.add_option('--jsrun_np_max', dest='blueos_np_max', type='int',
+                      help='''Blueos option: Over-rides test specific settings
+                      of np (number of processors) if the test is set greater
+                      than the value provided.''')
     parser.add_option('--jsrun_bind', dest='blueos_jsrun_bind',
                       default='unset',
                       help='''Blueos option: jsrun --bind option. "none",

--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -184,7 +184,7 @@ def add_blueos_only_options(parser):
                       settings of np (number of processors).  Useful for GPU
                       tests where the 4 MPI and 4 GPU devices are a common
                       testing scenario''')
-    parser.add_option('--lsrun_np_max', dest='blueos_np_max', type='int',
+    parser.add_option('--lrun_np_max', dest='blueos_np_max', type='int',
                       help='''Blueos option: Over-rides test specific settings
                       of np (number of processors) if the test is set greater
                       than the value provided.''')


### PR DESCRIPTION
Adds options that are similar to the existing jsrun_np and lsrun_np options, but with additional logic to only override the np set for tests if the np is larger than the number provided to these options. This way tests that are meant to run on less processors than specified aren't moved to higher counts.t

This PR will close: https://github.com/LLNL/ATS/issues/94