### PR TITLE
Expanding documentation of an option

### DIFF
--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -332,7 +332,11 @@ def add_more_options(parser):
                        help='''Run each test consecutively. Do not run
                        concurrent test jobs.''')
     parser.add_option('--nosrun', action='store_true',
-                      help='Slurm option: Run the code without srun.')
+                      help='''Slurm option: Run the code without srun. This
+                      option can also be used on BlueOS to run ALL test on
+                      a login node as it circumvents the login node check.
+                      If the tests need to be run on a working node, then
+                      the tests themselves will need to get an allocation.''')
     parser.add_option('--salloc', action='store_true',
                       help='Slurm option: Run the code with salloc rather than srun.')
     parser.add_option('--showGroupStartOnly', action='store_true',

--- a/docs/source/ats.rst
+++ b/docs/source/ats.rst
@@ -146,6 +146,11 @@ ATS installation.
 --nobatch
    Do not run any "batch" tests..
 
+--nosrun
+   Run the code without srun. This option can also be used on BlueOS to run ALL test on
+   a login node as it circumvents the login node check. If the tests need to be run on
+   a working node, then the tests themselves will need to get an allocation.
+
 --npMax value
    Value is an integer, the maximum number of tests to run at once (on a node, 
    if multinode machine).  Some machines allow you to set this higher than
@@ -1468,6 +1473,12 @@ The class ``AtsTest`` is available to users as ``ats.AtsTest``.
    .. attribute:: waitUntil
 
       A list of serial numbers of tests this one must wait for.
+
+   .. attribute:: nosrun
+
+      Boolean value, runs the code without srun when ``True``. This can also be
+      used to circumvent the login node check so that a test can be run on a login
+      node. When used it will be up to the test to get an allocation if needed.
 
    .. method:: set (status, message)
 


### PR DESCRIPTION
This PR simply adds documentation (on the --help level) about the behavior of one of our existing options, --nosrun. Also adds the --nosrun option and the test class attribute nosrun to the documentation (ast.rst).

This PR will close: https://github.com/LLNL/ATS/issues/62 as using the option, as described in the updated documentation, will allow a user to bypass the login node check on blueos, so that tests can be run on either the login node or custom (external to ATS) allocations.