### PR TITLE
Removing flux mini as it is deprecated

### DIFF
--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -120,7 +120,7 @@ class FluxScheduled(lcMachines.LCMachineCore):
 
         :param test: the test to be run, of type ATSTest. Defined in /ats/tests.py.
         """
-        ret = "flux mini run -o cpu-affinity=per-task -o mpibind=off".split()
+        ret = "flux run -o cpu-affinity=per-task -o mpibind=off".split()
         np = test.options.get("np", 1)
     
         FluxScheduled.set_nt_num_nodes(self, test)

--- a/ats/tools/atsflux.py
+++ b/ats/tools/atsflux.py
@@ -140,7 +140,7 @@ def main():
         # else start flux from the login node
         else:
             cmd = [
-                "flux", "mini", "alloc", 
+                "flux", "alloc",
                 "-N", f"{args.numNodes}",
                 "-n", f"{total_cores}",
                 "-t", f"{args.job_time}m",


### PR DESCRIPTION
This PR removes flux mini in favor of flux alloc and flux run. This avoids the warning we are currently seeing and alleviates a potential future problem.

This PR closes: https://github.com/LLNL/ATS/issues/117