### PR TITLE
Feature/v hemish/modified undefine

### DIFF
--- a/ats/management.py
+++ b/ats/management.py
@@ -150,10 +150,10 @@ Attributes:
         test_environment.update(definitions)
 
     def undefine(*args):
-        "Remove one or more symbols for input files."
-        for x in args:
-            if x in test_environment:
-                del test_environment[x]
+        """Remove one or more symbols from input files."""
+        for symbol in args:
+            test_environment.pop(symbol, None)
+
 
     def get(self, name):
         """Return the definition of name from the test environment.

--- a/ats/management.py
+++ b/ats/management.py
@@ -8,21 +8,15 @@ from ats.tests import AtsTest
 from ats.log import log, terminal
 from ats.parser import AtsCodeParser, AtsFileParser
 
-def standardIntrospection(line):
-    "Standard magic detector for input."
-    if line.startswith("#ATS:"):
-        return line[5:]
-    else:
-        return None
+def standard_introspection(line):
+    """Standard magic detector for input."""
+    prefix = "#ATS:"
+    return line[len(prefix):] if line.startswith(prefix) else None
 
-def areBrothers(t1, t2):
-    "are two tests part of a set of related tests?"
-    if t1.group is t2.group:
-        return True
-    elif t1 in t2.dependents or t2 in t1.dependents:
-        return True
-    else:
-        return False
+def are_brothers(t1, t2):
+    """Are two tests part of a set of related tests?"""
+    return t1.group is t2.group or t1 in t2.dependents or t2 in t1.dependents
+
 
 class AtsManager (object):
     """This class is instantiated as a singleton instance, manager.

--- a/ats/management.py
+++ b/ats/management.py
@@ -62,7 +62,7 @@ Attributes:
         AtsTest.restart()
 
     def filter (self, *filters):
-        "Add filters to the list. Clear list if no arguments."
+        "Add filters to the list. Clear list if no argum    ents."
         if not filters:
             self.filters = []
             log('Filter list empty.', echo=self.verbose)
@@ -86,17 +86,19 @@ Attributes:
             self.filters.append(f)
             log ('Added filter:', repr(f))
 
-    def filterenv (self, test):
-        """Compute the environment in which filters for test will be
-            evaluated."""
+    def filter_env(self, test):
+        """Compute the environment in which filters for test will be evaluated."""
         if not isinstance(test, AtsTest):
-            raise AtsError('filterenv argument must be a test instance.')
-        fe = {}
-        for f in _filterwith:
-            exec(f, fe)
-        fe.update(test.options)
-        fe.update(testEnvironment)
-        return fe
+            raise AtsError('filter_env argument must be a test instance.')
+
+        filter_env = {}
+        for filter_expr in _filterwith:
+            exec(filter_expr, filter_env)
+
+        filter_env.update(test.options)
+        filter_env.update(test_environment)
+
+        return filter_env
 
     def find_unmatched (self, test):
         """Does this manager's filters match the given test properties?
@@ -134,30 +136,30 @@ Attributes:
         log("Test environment symbols:", logging=logging, echo=echo)
         log.indent()
         if not words:
-            words = list(testEnvironment.keys())
+            words = list(test_environment.keys())
             words.sort()
         for key in words:
             try:
-                log(key,":", testEnvironment[key], logging=logging, echo=echo)
+                log(key,":", test_environment[key], logging=logging, echo=echo)
             except KeyError:
                 log("Not defined:", key, logging=logging, echo=echo)
         log.dedent()
 
     def define(self, **definitions):
         "Define symbols for input files."
-        testEnvironment.update(definitions)
+        test_environment.update(definitions)
 
     def undefine(*args):
         "Remove one or more symbols for input files."
         for x in args:
-            if x in testEnvironment:
-                del testEnvironment[x]
+            if x in test_environment:
+                del test_environment[x]
 
     def get(self, name):
         """Return the definition of name from the test environment.
         """
-        if name in testEnvironment:
-            return testEnvironment.get(name)
+        if name in test_environment:
+            return test_environment.get(name)
 
         raise AtsError("Could not find name %s in vocabulary." % name)
 
@@ -173,7 +175,7 @@ Attributes:
             log("source:", ' '.join(paths), echo=True)
 
         introspector = vocabulary.get('introspection',
-                   testEnvironment.get('introspection', standardIntrospection))
+                   test_environment.get('introspection', standardIntrospection))
 
         for path in paths:
             self._source(path, introspector, vocabulary)
@@ -211,7 +213,7 @@ Attributes:
         unstick() #clear sticky list at the start of a file.
         AtsTest.waitNewSource()
 
-        testenv = dict(testEnvironment)
+        testenv = dict(test_environment)
         testenv.update(vocabulary)
         testenv['SELF'] = t1
         atstext = []
@@ -1224,7 +1226,7 @@ def filterdefs (text=None):
         _filterwith.append(text)
 
 # Set up the testing environment, add statuses to it.
-testEnvironment = {
+test_environment = {
         "debug": debug,
         "manager": manager,
         "test": test,
@@ -1263,7 +1265,7 @@ testEnvironment = {
         "onSave": onSave,
         "getResults": getResults,
     }
-testEnvironment.update(statuses)
+test_environment.update(statuses)
 
 if __name__ == "__main__":
     logDefinitions()


### PR DESCRIPTION
Changes made:

- Updated the docstring to use triple double-quotes for consistency with PEP 257.
- Replaced if x in test_environment followed by del test_environment[x] with a single line using test_environment.pop(symbol, None). The pop method removes the item with the specified key if it exists, and does nothing if the key is not found, making the code more concise.
Why Pop over Del: 
Using pop over the del method in this specific case offers a more concise and readable solution. The pop method with a default value of None allows you to remove an item with the specified key if it exists, and does nothing if the key is not found, effectively combining the if condition and the del statement into a single line.