### PR TITLE
Bugfix/dawson/exit code deux

### DIFF
--- a/ats/__main__.py
+++ b/ats/__main__.py
@@ -7,8 +7,10 @@ import ats
 
 def main():
     result = ats.manager.main()
-    return result
-
+    if result:
+        return 0
+    else
+        return 1
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/ats/__main__.py
+++ b/ats/__main__.py
@@ -9,7 +9,7 @@ def main():
     result = ats.manager.main()
     if result:
         return 0
-    else
+    else:
         return 1
 
 if __name__ == "__main__":

--- a/ats/tools/atsflux.py
+++ b/ats/tools/atsflux.py
@@ -186,9 +186,11 @@ def main():
     cmd.append(myats)
     cmd.extend(extra_args)
     print("Executing: " + " ".join(cmd))
-    #sys.exit("debug")
 
-    subprocess.run(cmd, text=True)
+    completed_process subprocess.run(cmd, text=True)
+
+    #  return return code from flux or salloc
+    return(completed_process.returncode);
 
 
 if __name__ == "__main__":

--- a/ats/tools/atsformat.py
+++ b/ats/tools/atsformat.py
@@ -51,15 +51,21 @@ def main() -> None:
     ]
 
     print("ATS: Running Black formatter...")
-    subprocess.run(BLACK_CMD + BLACK_OPTIONS + args.path)
+    completed_process = subprocess.run(BLACK_CMD + BLACK_OPTIONS + args.path)
     print("ATS: Black formatter done.\n")
+    if completed_process.returncode != 0:
+        return(completed_process.returncode)
 
     print("ATS: Running isort formatter...")
-    subprocess.run(ISORT_CMD + ISORT_OPTIONS + args.path)
+    completed_process = subprocess.run(ISORT_CMD + ISORT_OPTIONS + args.path)
     print("ATS: isort formatter done.")
+    if completed_process.returncode != 0:
+        return(completed_process.returncode)
 
     for machine_file in Path("ats", "atsMachines").glob("*.py"):
         unformat_ATS_headers(machine_file)
+
+    return(0)
 
 
 if __name__ == "__main__":

--- a/ats/tools/atslite1.py
+++ b/ats/tools/atslite1.py
@@ -62,7 +62,7 @@ def main():
     elif 'blueos' in sys_type:
         numNodes = 1
     else:
-        numNodes = 4
+        numNodes = 3
 
     my_bank = "guests"
 
@@ -167,7 +167,8 @@ def main():
 
     print("Executing: %s" % cmd)
 
-    subprocess.run(cmd.split(), text=True)
+    completed_process = subprocess.run(cmd.split(), text=True)
+    return completed_process.returncode
 
 # -----------------------------------------------------------------------------
 #  Startup

--- a/ats/tools/atslite3.py
+++ b/ats/tools/atslite3.py
@@ -59,7 +59,7 @@ def main():
     elif 'blueos' in sys_type:
         numNodes = 1
     else:
-        numNodes = 4
+        numNodes = 3
 
     my_bank = "guests"
 
@@ -171,10 +171,7 @@ def main():
 
     ats_lite_ats.wait()
 
-    return_code = ats_lite_ats.returncode
-    #print "ATS finished, exiting with return code "
-    #print return_code
-    sys.exit(return_code)
+    return ats_lite_ats.returncode
 
 # -----------------------------------------------------------------------------
 #  Startup


### PR DESCRIPTION
Have main installed ats scripts return 0 on success
and non 0 on failure.

Track down each entry point for the scripts generated 
by the poetry install, which is in the [scripts] section of
pyproject.toml.   Make the change fo reach entry point.