### PR TITLE
Adding missed "equals"

### DIFF
--- a/ats/__main__.py
+++ b/ats/__main__.py
@@ -7,6 +7,9 @@ import ats
 
 def main():
     result = ats.manager.main()
+
+    # Return values need to be modified because code returns bool checking for errors
+    # if there was no error then we return False, but codes using us expect 0 as a successful run
     if result:
         return 0
     else:

--- a/ats/tools/atsflux.py
+++ b/ats/tools/atsflux.py
@@ -187,10 +187,10 @@ def main():
     cmd.extend(extra_args)
     print("Executing: " + " ".join(cmd))
 
-    completed_process subprocess.run(cmd, text=True)
+    completed_process = subprocess.run(cmd, text=True)
 
     #  return return code from flux or salloc
-    return(completed_process.returncode);
+    return(completed_process.returncode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is a quick bug fix to add a missing equal for the return in atsflux.py. Also removes a semicolon not needed in python.

Added a comment to explain our return from main, to hopefully reduce confusion for other collaborators.