### PR TITLE
BlueOS option update

### DIFF
--- a/ats/atsMachines/lsf_asq.py
+++ b/ats/atsMachines/lsf_asq.py
@@ -333,6 +333,7 @@ class lsfMachine (machines.Machine):
         # Command line --blueos_np_max option will over-ride the test specific np option if
         # the test specific option is greater than the command line option
         if test.blueos_np_max > 0 and  test.np > test.blueos_np_max:
+            print("Deprecation Warning: lrun_np_max and jsrun_np_max are deprecated and will be removed in the future. Use test_np_max instead.")
             test.np = test.blueos_np_max
             np = test.blueos_np_max
 

--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -207,6 +207,16 @@ def add_blueos_only_options(parser):
                       settings of np (number of processors).  Useful for GPU
                       tests where the 4 MPI and 4 GPU devices are a common
                       testing scenario''')
+    parser.add_option('--lrun_np_max', dest='blueos_np_max', type='int',
+                      help='''DEPRECATED: use test_np_max
+                      Blueos option: Over-rides test specific settings
+                      of np (number of processors) if the test is set greater
+                      than the value provided.''')
+    parser.add_option('--jsrun_np_max', dest='blueos_np_max', type='int',
+                      help='''DEPRECATED: use test_np_max
+                      Blueos option: Over-rides test specific settings
+                      of np (number of processors) if the test is set greater
+                      than the value provided.''')
     parser.add_option('--test_np_max', dest='blueos_np_max', type='int',
                       help='''Blueos option: Over-rides test specific settings
                       of np (number of processors) if the test is set greater

--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -207,7 +207,7 @@ def add_blueos_only_options(parser):
                       settings of np (number of processors).  Useful for GPU
                       tests where the 4 MPI and 4 GPU devices are a common
                       testing scenario''')
-    parser.add_option('--lrun_np_max', dest='blueos_np_max', type='int',
+    parser.add_option('--test_np_max', dest='blueos_np_max', type='int',
                       help='''Blueos option: Over-rides test specific settings
                       of np (number of processors) if the test is set greater
                       than the value provided.''')
@@ -229,10 +229,6 @@ def add_blueos_only_options(parser):
                       of np (number of processors). Useful for GPU tests where
                       the 4 MPI and 4 GPU devices are a common testing
                       scenario''')
-    parser.add_option('--jsrun_np_max', dest='blueos_np_max', type='int',
-                      help='''Blueos option: Over-rides test specific settings
-                      of np (number of processors) if the test is set greater
-                      than the value provided.''')
     parser.add_option('--jsrun_bind', dest='blueos_jsrun_bind',
                       default='unset',
                       help='''Blueos option: jsrun --bind option. "none",


### PR DESCRIPTION
This PR adds documentation and a message when lrun_np_max or jsrun_np_max are used to indicated that they are deprecated. As well as adding a third option, that does the same as the previous two, but will be used in the future to make options between different systems similar.