### PR TITLE
Move priority calculation to separate method

### DIFF
--- a/ats/schedulers.py
+++ b/ats/schedulers.py
@@ -31,7 +31,9 @@ class StandardScheduler (object):
                                name='atss.log',
                                logging=configuration.options.logUsage,
                                echo=False)
+        self.calculatePriority(interactiveTests)
 
+    def calculatePriority(self, interactiveTests):
         for t in interactiveTests:
             waitOnMe = [x for x in interactiveTests if t in x.waitUntil]
             t.totalPriority += sum([w.priority for w in waitOnMe])


### PR DESCRIPTION
The priority calculation can be improved if the tests are already sorted by priority, however because of the global module initializations in prioritize(), it cannot be overridden without overridding all methods that reference machine or configuration.

Splitting the priority calculation into a separate method allows it to be overridden easily.