### PR TITLE
Adding options to reduce prints

### DIFF
--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -428,6 +428,11 @@ class FluxScheduled(lcMachines.LCMachineCore):
                      test.num_nodes, test.np,
                      test.cpus_per_task, test.gpus_per_task, test.num_nodes)), echo=True)
 
+        msg = '%s #%4d %s,  nn=%d, np=%d, ngpu=%d %s' % \
+            ("Stop ", test.serialNumber, test.name, test.num_nodes, test.np, test.gpus_per_task, time.asctime())
+
+        return msg
+
     def periodicReport(self):
         """
         Report on current status of tasks and processor availability.

--- a/ats/atsMachines/lsf_asq.py
+++ b/ats/atsMachines/lsf_asq.py
@@ -212,6 +212,7 @@ class lsfMachine (machines.Machine):
             print("%s options.nosrun              = %s " % (DEBUG_LSF, options.nosrun))
             print("%s options.checkForAtsProc     = %s " % (DEBUG_LSF, options.checkForAtsProc))
             print("%s options.showGroupStartOnly  = %s " % (DEBUG_LSF, options.showGroupStartOnly))
+            print("%s options.removeEndNote       = %s " % (DEBUG_LSF, options.removeEndNote))
             print("%s options.skip                = %s " % (DEBUG_LSF, options.skip))
             print("%s options.blueos_exclusive    = %s " % (DEBUG_LSF, options.blueos_exclusive))
             print("%s options.mpibind             = %s " % (DEBUG_LSF, options.mpibind))

--- a/ats/atsMachines/lsf_asq.py
+++ b/ats/atsMachines/lsf_asq.py
@@ -212,6 +212,7 @@ class lsfMachine (machines.Machine):
             print("%s options.nosrun              = %s " % (DEBUG_LSF, options.nosrun))
             print("%s options.checkForAtsProc     = %s " % (DEBUG_LSF, options.checkForAtsProc))
             print("%s options.showGroupStartOnly  = %s " % (DEBUG_LSF, options.showGroupStartOnly))
+            print("%s options.removeStartNote     = %s " % (DEBUG_LSF, options.removeStartNote))
             print("%s options.removeEndNote       = %s " % (DEBUG_LSF, options.removeEndNote))
             print("%s options.skip                = %s " % (DEBUG_LSF, options.skip))
             print("%s options.blueos_exclusive    = %s " % (DEBUG_LSF, options.blueos_exclusive))

--- a/ats/atsMachines/lsf_asq.py
+++ b/ats/atsMachines/lsf_asq.py
@@ -849,7 +849,7 @@ class lsfMachine (machines.Machine):
         if my_environment == "INTERACTIVE":
             os.system("stty sane")  # Keep the interactive terminal sane on blueos
 
-        print(msg)
+        # print(msg)
 
         if my_environment == "INTERACTIVE":
             os.system("stty sane")  # Keep the interactive terminal sane on blueos
@@ -883,6 +883,7 @@ class lsfMachine (machines.Machine):
                 print("ATS Error: Can not find file '%s'\n" % test.rs_filename)
 
         #print self.nodesInUse
+        return msg
 
     def periodicReport(self):
         "Report on current status of tasks"

--- a/ats/atsMachines/lsf_asq.py
+++ b/ats/atsMachines/lsf_asq.py
@@ -849,8 +849,6 @@ class lsfMachine (machines.Machine):
         if my_environment == "INTERACTIVE":
             os.system("stty sane")  # Keep the interactive terminal sane on blueos
 
-        # print(msg)
-
         if my_environment == "INTERACTIVE":
             os.system("stty sane")  # Keep the interactive terminal sane on blueos
 

--- a/ats/atsMachines/slurmProcessorScheduled.py
+++ b/ats/atsMachines/slurmProcessorScheduled.py
@@ -169,6 +169,7 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
             print("%s options.salloc              = %s " % (DEBUG_SLURM, options.salloc))
             print("%s options.checkForAtsProc     = %s " % (DEBUG_SLURM, options.checkForAtsProc))
             print("%s options.showGroupStartOnly  = %s " % (DEBUG_SLURM, options.showGroupStartOnly))
+            print("%s options.removeEndNote       = %s " % (DEBUG_SLURM, options.removeEndNote))
             print("%s options.skip                = %s " % (DEBUG_SLURM, options.skip))
             print("%s options.exclusive           = %s " % (DEBUG_SLURM, options.exclusive))
             print("%s options.mpibind             = %s " % (DEBUG_SLURM, options.mpibind))

--- a/ats/atsMachines/slurmProcessorScheduled.py
+++ b/ats/atsMachines/slurmProcessorScheduled.py
@@ -650,7 +650,8 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
         msg = '%s #%4d %s,  nn=%d, np=%d, nt=%d, ngpu=0 %s' % \
             ("Stop ", test.serialNumber, test.name, my_nn, my_np, my_nt, time.asctime())
 
-        print(msg)
+        # print(msg)
+        return msg
 
     def periodicReport(self):
         "Report on current status of tasks"

--- a/ats/atsMachines/slurmProcessorScheduled.py
+++ b/ats/atsMachines/slurmProcessorScheduled.py
@@ -169,6 +169,7 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
             print("%s options.salloc              = %s " % (DEBUG_SLURM, options.salloc))
             print("%s options.checkForAtsProc     = %s " % (DEBUG_SLURM, options.checkForAtsProc))
             print("%s options.showGroupStartOnly  = %s " % (DEBUG_SLURM, options.showGroupStartOnly))
+            print("%s options.removeStartNote     = %s " % (DEBUG_SLURM, options.removeStartNote))
             print("%s options.removeEndNote       = %s " % (DEBUG_SLURM, options.removeEndNote))
             print("%s options.skip                = %s " % (DEBUG_SLURM, options.skip))
             print("%s options.exclusive           = %s " % (DEBUG_SLURM, options.exclusive))

--- a/ats/atsMachines/slurmProcessorScheduled.py
+++ b/ats/atsMachines/slurmProcessorScheduled.py
@@ -650,7 +650,6 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
         msg = '%s #%4d %s,  nn=%d, np=%d, nt=%d, ngpu=0 %s' % \
             ("Stop ", test.serialNumber, test.name, my_nn, my_np, my_nt, time.asctime())
 
-        # print(msg)
         return msg
 
     def periodicReport(self):

--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -380,8 +380,11 @@ def add_more_options(parser):
     parser.add_option('--showGroupStartOnly', action='store_true',
                       help='''Only show start of first test in group, not
                       subsequent steps.''')
+    parser.add_option('--removeStartNote', action='store_true',
+                      help='''Remove message printed before the test has started
+                      running.''')
     parser.add_option('--removeEndNote', action='store_true',
-                      help='''Remove message printed after test has finished
+                      help='''Remove message printed after the test has finished
                       running.''')
     parser.add_option('--skip', action='store_true',
                       help='''skip actual execution of the tests, but show

--- a/ats/configuration.py
+++ b/ats/configuration.py
@@ -380,6 +380,9 @@ def add_more_options(parser):
     parser.add_option('--showGroupStartOnly', action='store_true',
                       help='''Only show start of first test in group, not
                       subsequent steps.''')
+    parser.add_option('--removeEndNote', action='store_true',
+                      help='''Remove message printed after test has finished
+                      running.''')
     parser.add_option('--skip', action='store_true',
                       help='''skip actual execution of the tests, but show
                       filtering results and missing test files.''')

--- a/ats/machines.py
+++ b/ats/machines.py
@@ -317,8 +317,10 @@ class MachineCore(object):
            #note test.status is not necessarily status after this!
            #see test.expectedResult
 
+        endNote = self.noteEnd(test)  #to be defined in children
+
         if not configuration.options.removeEndNote:
-            self.noteEnd(test)  #to be defined in children
+            print(endNote)
 
         # now close the outputs
         if test.stdOutLocGet() != 'terminal':

--- a/ats/machines.py
+++ b/ats/machines.py
@@ -317,7 +317,8 @@ class MachineCore(object):
            #note test.status is not necessarily status after this!
            #see test.expectedResult
 
-        self.noteEnd(test)  #to be defined in children
+        if not configuration.options.removeEndNote:
+            self.noteEnd(test)  #to be defined in children
 
         # now close the outputs
         if test.stdOutLocGet() != 'terminal':

--- a/ats/machines.py
+++ b/ats/machines.py
@@ -319,8 +319,9 @@ class MachineCore(object):
 
         endNote = self.noteEnd(test)  #to be defined in children
 
-        if not configuration.options.removeEndNote:
-            print(endNote)
+        if endNote: # Check that there is something to be printed
+            if not configuration.options.removeEndNote: # Does the user want it to be printed
+                print(endNote)
 
         # now close the outputs
         if test.stdOutLocGet() != 'terminal':

--- a/ats/schedulers.py
+++ b/ats/schedulers.py
@@ -81,7 +81,8 @@ class StandardScheduler (object):
                 self.schedule("Chose #%d to start." % nextTest.serialNumber)
             self.addBlock(nextTest)
             result = machine.startRun(nextTest)
-            self.logStart(nextTest, result)
+            if not configuration.options.removeStartNote:
+                self.logStart(nextTest, result)
             if not result:
                 self.removeBlock(nextTest)
                 break   # failure to launch, let it come back if tests left.


### PR DESCRIPTION
This PR adds two options: `--removeStartNote` and `--removeEndNote`

removeStartNote: removes the logStart() call from step(). This gets rid of the "Start" message automatically printed by ATS
removeEndNote: removes the noteEnd() call from testEnded(). This gets rid of the "Stop" message automatically printed by ATS

Additionally, this PR adds a message printed at the end of tests when they are run using flux, to be consistent with the other schedulers.