### PR TITLE
Same node option

### DIFF
--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -316,9 +316,9 @@ class FluxScheduled(lcMachines.LCMachineCore):
             if self.flux_exclusive:
                 ret.append("--exclusive")
 
-        if test.np > self.coresPerNode and same_node:   # Need to limit cores to be the max on the node if we
+        if test.np > self.coresPerNode and same_node:   # Need to limit cores to be the max on the node if we want to run on the same node
             log(f"ATS WARNING: Limiting cores, because of same_node option, to match max: {self.coresPerNode}")
-            ret.append(f"-n{self.coresPerNode}")        # want to run on the same node
+            ret.append(f"-n{self.coresPerNode}")
         else:
             ret.append(f"-n{test.np}")
         ret.append(f"-c{test.cpus_per_task}")   # Needs to be set properly for threaded or gpu runs

--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -62,6 +62,10 @@ class FluxScheduled(lcMachines.LCMachineCore):
             self.coresPerGPU = 0
         self.coresPerNode = int(self.numCores / self.numNodes)
 
+        # Strings used to determine which node a user wants the test to run
+        # Used with same_node var
+        self.node_list = []
+
         # Maintain for backwards compatability with projects
         # Allow user to over-ride the coresPerNode
         # Other schedulers call this npMax, but for flux we are calling this coresPerNode
@@ -262,6 +266,19 @@ class FluxScheduled(lcMachines.LCMachineCore):
                 max_time = self.timelimit
 
             ret.append(f"-t{max_time}")
+
+
+
+        import pprint
+
+        same_node = test.options.get('same_node', None)
+        if same_node is not None:
+            if same_node not in self.node_list:
+                self.node_list.append(same_node)
+                pprint.pprint(self.node_list)
+            print(f"This is the node that we are trying to run on:{self.node_list.index(same_node) % self.numNodes}")
+            ret.append(f"--requires=rank:{self.node_list.index(same_node) % self.numNodes}")
+
 
         """
         Need to set -n{np} and -c{test.cpus_per_task}.  But we also need to account for accessing

--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -277,7 +277,7 @@ class FluxScheduled(lcMachines.LCMachineCore):
                 self.node_list.append(same_node)
                 pprint.pprint(self.node_list)
             print(f"This is the node that we are trying to run on:{self.node_list.index(same_node) % self.numNodes}")
-            ret.append(f"--requires=rank:{self.node_list.index(same_node) % self.numNodes}")
+            ret.append(f"--requires=-rank:{self.node_list.index(same_node) % self.numNodes}")
 
 
         """

--- a/docs/source/ats.rst
+++ b/docs/source/ats.rst
@@ -163,6 +163,13 @@ ATS installation.
 --oneFailure
    Stop if a test fails.
 
+--removeStartNote
+   Removes the messages printed at the start of a test running.
+
+--removeEndNote
+   Removes the message printed at the end of a test running. Will still get results
+   printed with pass/fail, just no "stop".
+
 --serial
    Run only one job at a time.
 
@@ -1039,7 +1046,7 @@ same_node
    to be run on the same node. Useful for tests that depend on some data output
    by another test that might not be accessable from other nodes. NOTE: Using this
    option will limit -N 1 and -n to max on one node, if more than that were
-   requested. Ex: --same_node='abc'
+   requested. Ex: same_node='abc'
 
 Extra Arguments On The Executable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/ats.rst
+++ b/docs/source/ats.rst
@@ -1034,6 +1034,11 @@ magic
 hideOutput
    If true, do not print magic output lines in the log.
 
+same_node
+   ONLY WORKS ON FLUX. Specify a string identifier for the tests that you want
+   to be run on the same node. Useful for tests that depend on some data output
+   by another test that might not be accessable from other nodes. Ex: --same_node='abc'
+
 Extra Arguments On The Executable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/ats.rst
+++ b/docs/source/ats.rst
@@ -1037,7 +1037,9 @@ hideOutput
 same_node
    ONLY WORKS ON FLUX. Specify a string identifier for the tests that you want
    to be run on the same node. Useful for tests that depend on some data output
-   by another test that might not be accessable from other nodes. Ex: --same_node='abc'
+   by another test that might not be accessable from other nodes. NOTE: Using this
+   option will limit -N 1 and -n to max on one node, if more than that were
+   requested. Ex: --same_node='abc'
 
 Extra Arguments On The Executable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/ats.rst
+++ b/docs/source/ats.rst
@@ -1042,11 +1042,11 @@ hideOutput
    If true, do not print magic output lines in the log.
 
 same_node
-   ONLY WORKS ON FLUX. Specify a string identifier for the tests that you want
-   to be run on the same node. Useful for tests that depend on some data output
-   by another test that might not be accessable from other nodes. NOTE: Using this
-   option will limit -N 1 and -n to max on one node, if more than that were
-   requested. Ex: same_node='abc'
+   ONLY WORKS ON FLUX (ATS can run Flux under slurm). Specify a string identifier
+   for the tests that you want to be run on the same node. Useful for tests that
+   depend on some data output by another test that might not be accessable from
+   other nodes. NOTE: Using this option will limit -N 1 and -n to max on one node,
+   if more than that were requested. Ex: same_node='abc'
 
 Extra Arguments On The Executable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR adds an option, that works under the Flux scheduler, to allow users to run tests on the same node. It is a per-test option where a string is specified and tests with the same string will be run on the same node. Setting this option will limit the number of nodes you can use for the test to one (-N1) and the number of cores to the maximum on the node (-nMAX), if the user requests more cores than on the node, otherwise -n stays the same.
This PR will close: https://github.com/LLNL/ATS/issues/103

Note: while this is an option working under Flux, we do have Flux working under slrum.

This PR also adds documentation for two previously added command line options: removeStartNote and removeEndNote.