### PR TITLE
Flux timeouts

### DIFF
--- a/ats/machines.py
+++ b/ats/machines.py
@@ -200,7 +200,8 @@ class MachineCore(object):
                 test.statusCode = 0
             if test.statusCode == 0:                               # process is done
                 status = PASSED
-            elif "flux" in configuration.MACHINE_TYPE and test.statusCode == 142:
+            # This checks for flux timeouts since ATS' method for determining timeouts doesnt work with flux
+            elif "flux" in configuration.MACHINE_TYPE and test.statusCode == 142: # 142 is the return code for a timeout from flux
                 status = TIMEDOUT
             else:
                 # Coding to detect LSF deficiencies

--- a/ats/machines.py
+++ b/ats/machines.py
@@ -55,12 +55,12 @@ class MachineCore(object):
         end time is set if time elapsed exceeds time limit """
         from ats import configuration
 
-        timeNow= time.time()
+        timeNow = time.time()
         # Add small increment to flags jobs that 
         # are close to timing out as timing out. Without this
         # they were occasionally mis categorized as FAILED in
         # later processing.
-        timePassed= (timeNow - test.startTime) + 0.2
+        timePassed = (timeNow - test.startTime) + 0.2
         #cut = configuration.cuttime
         fraction = timePassed / test.timelimit.value
 
@@ -117,7 +117,7 @@ class MachineCore(object):
         """
         from ats import configuration
         test.child.poll()
-        #print test.child.returncode
+        # print(f"This is the return code for the test:{test.child.returncode}")
         if test.child.returncode is None:
             overtime, fraction = self.checkForTimeOut(test)
             #print "DEBUG getStatus 100"
@@ -200,6 +200,8 @@ class MachineCore(object):
                 test.statusCode = 0
             if test.statusCode == 0:                               # process is done
                 status = PASSED
+            elif "flux" in configuration.MACHINE_TYPE and test.statusCode == 142:
+                status = TIMEDOUT
             else:
                 # Coding to detect LSF deficiencies
                 # Implemented 2018-12-12


### PR DESCRIPTION
This PR addresses the problem that we were seeing with tests, run using Flux, stating that they failed even though it was a time out. Now we check if we are running on a Flux machine and check for the return code from flux and determine that there was a timeout.

There's also a debugging print that I updated to work with python3, but left in because it was there before.

Closes: https://github.com/LLNL/ATS/issues/116