### PR TITLE
Update opens used for readlines.

### DIFF
--- a/ats/machines.py
+++ b/ats/machines.py
@@ -500,7 +500,7 @@ class MachineCore(object):
 
         if hasattr(test, 'rs_filename'):
             if os.path.isfile(test.rs_filename):
-                myfile = open(test.rs_filename, mode='r')
+                myfile = open(test.rs_filename, mode='r', errors=ignore)
                 all_of_it = myfile.read()
                 myfile.close()
                 print("%sjsrun_rs =\n%s" % (magic, all_of_it), file=test.outhandle)

--- a/ats/reportutils.py
+++ b/ats/reportutils.py
@@ -127,7 +127,7 @@ def writeFailedCodeTestCase(f, test, err_path):
     msg = ""
     err_files = glob.glob(os.path.join(err_path, '*' + str(test.serialNumber) + '*.log.err'))
     if len(err_files) > 0:
-        with open(err_files[0], 'r') as logferr:
+        with open(err_files[0], 'r', errors='ignore') as logferr:
             # not readlines() - there are standard xml escapes to fix, we don't want to iterate over
             # the whole message.
             rawmsg = logferr.read()
@@ -137,7 +137,7 @@ def writeFailedCodeTestCase(f, test, err_path):
 
     log_files = glob.glob(os.path.join(err_path, '*' + str(test.serialNumber) + '*.log'))
     if len(log_files) > 0:
-        with open(log_files[0], 'r') as logf:
+        with open(log_files[0], 'r', errors='ignore') as logf:
             rawmsg = logf.read()
             msg += "***** ats log file: *****\n running from clone code \n"
             msg += cleanErrorMessage(rawmsg)

--- a/ats/tests.py
+++ b/ats/tests.py
@@ -631,7 +631,7 @@ class AtsTest (object):
 
         if self.testStdout != 'terminal':
             try:
-                f = open(self.outname, 'r')
+                f = open(self.outname, 'r', errors='ignore')
             except IOError as e:
                 self.notes = ['Missing output file.']
                 log('Missing output file', self.outname, e)


### PR DESCRIPTION
Update opens with errors='ignore' in attempt to stop the python coding in ATS from dying when it reads output generated by applications which are not utf-8 valid.  This can happen when applications print garbage output -- but when this happens the python in ATS breaks and the testing breaks.

Try to simply ignore such garbage output.