### PR TITLE
Reduce output for same_node setup

### DIFF
--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -144,6 +144,20 @@ class FluxScheduled(lcMachines.LCMachineCore):
         Works for any node prefix (e.g., rzadams, elcap, tuo, syz).
         """
         if FluxScheduled._cached_nodes is None:
+            # Query instance-level -> >0 = in allocation
+            inst_lvl = 0
+            inst_lvl_out = subprocess.run(['flux', 'getattr', 'instance-level'], capture_output=True)
+            if inst_lvl_out.returncode == 0:
+                try:
+                    inst_lvl = int(inst_lvl_out.stdout.strip())
+                except ValueError:
+                    pass
+
+            if inst_lvl == 0:
+                raise RuntimeError(
+                    "flux instance-level is 0 or not set. Use of ATS same_node feature requires running ATS within an allocation."
+                )
+
             out = subprocess.check_output("flux resource list", shell=True).decode()
             nodelist_field = None
             for line in out.splitlines():

--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -400,7 +400,7 @@ class FluxScheduled(lcMachines.LCMachineCore):
 
         if same_node:   # Need to limit -N if we want to run on the same node
             if test.num_nodes > 0:   # Check that -N was set by user before giving warning
-                log(f"ATS WARNING: {test.name} : Limiting nodes to 1 be able to run on same node.", echo=True)
+                log(f"ATS WARNING: {test.name} : Limiting nodes to 1 to be able to run on same node.", echo=True)
             ret.append("-N1")
             ret.append("--exclusive")
         elif test.num_nodes > 0:

--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -169,7 +169,6 @@ class FluxScheduled(lcMachines.LCMachineCore):
             if nodelist_field is None:
                 raise RuntimeError("Could not find NODELIST field in flux resource list output. Use of ATS same_node feature requires running ATS within an allocation.")
             FluxScheduled._cached_nodes = self.expand_nodelist(nodelist_field)
-            log(("Info: Physical Hardware Nodes: %s" % FluxScheduled._cached_nodes), echo=True)
 
         nodes = FluxScheduled._cached_nodes
         if rel_index < 0 or rel_index >= len(nodes):
@@ -238,6 +237,10 @@ class FluxScheduled(lcMachines.LCMachineCore):
 
         if self.use_flux_rm:
             log("Info: Will use flux resource manager to verify free resources", echo=True)
+
+        if options.verbose:
+            if FluxScheduled._cached_nodes:
+                log(f"Info: Physical Hardware Nodes: {FluxScheduled._cached_nodes}", echo=True)
 
         if self.cpx or self.within_cpx_allocation():
             log("NOTICE: Running in CPX mode", echo=True)
@@ -364,6 +367,8 @@ class FluxScheduled(lcMachines.LCMachineCore):
                 self.node_list.append(same_node)
             rel_node = self.node_list.index(same_node) % self.numNodes
             physical_node = self.get_physical_node(rel_node)
+            if configuration.options.verbose:
+                log(f"{test.name}:{physical_node}", echo=True)
             ret.append(f"--requires=host:{physical_node}")
 
         """
@@ -395,7 +400,7 @@ class FluxScheduled(lcMachines.LCMachineCore):
 
         if same_node:   # Need to limit -N if we want to run on the same node
             if test.num_nodes > 0:   # Check that -N was set by user before giving warning
-                log("ATS WARNING: Limiting nodes to 1 be able to run on same node.", echo=True)
+                log(f"ATS WARNING: {test.name} : Limiting nodes to 1 be able to run on same node.", echo=True)
             ret.append("-N1")
             ret.append("--exclusive")
         elif test.num_nodes > 0:
@@ -407,7 +412,7 @@ class FluxScheduled(lcMachines.LCMachineCore):
                 ret.append("--exclusive")
 
         if test.np > self.coresPerNode and same_node:   # Need to limit cores to be the max on the node if we want to run on the same node
-            log(f"ATS WARNING: Limiting cores, because of same_node option, to match max: {self.coresPerNode}", echo=True)
+            log(f"ATS WARNING: {test.name} : Limiting cores, because of same_node option, to match max: {self.coresPerNode}", echo=True)
             ret.append(f"-n{self.coresPerNode}")
         else:
             ret.append(f"-n{test.np}")

--- a/ats/atsMachines/slurmProcessorScheduled.py
+++ b/ats/atsMachines/slurmProcessorScheduled.py
@@ -133,10 +133,6 @@ class SlurmProcessorScheduled(lcMachines.LCMachineCore):
             # ).decode().splitlines()
             # self._cached_nodes = out
 
-            # Optional logging
-            log(("Info: Physical Hardware Nodes: %s" % self._cached_nodes), echo=True)
-            # log(f"Info: Physical Hardware Nodes: {self._cached_nodes}", echo=True)
-
         nodes = self._cached_nodes
         if rel_index < 0 or rel_index >= len(nodes):
             raise IndexError(f"Relative index {rel_index} out of range (0-{len(nodes)-1})")
@@ -236,6 +232,10 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
             print("%s options.allInteractive      = %s " % (DEBUG_SLURM, options.allInteractive))
             print("%s options.filter              = %s " % (DEBUG_SLURM, options.filter))
             print("%s options.glue                = %s " % (DEBUG_SLURM, options.glue))
+
+        if options.verbose:
+            if self._cached_nodes:
+                log(f"Info: Physical Hardware Nodes: {self._cached_nodes}", echo=True)
 
         if options.npMax > 0:
             self.npMax = options.npMax
@@ -395,6 +395,8 @@ ATS NOTICE: Slurm sees ATS or Shell as itself using a CPU.
                 self.node_list.append(same_node)
             rel_node = self.node_list.index(same_node) % self.numNodes
             physical_node = self.get_physical_node(rel_node)
+            if configuration.options.verbose:
+                log(f"{test.name}:{physical_node}", echo=True)
             srun_nodelist = '--nodelist=%s' % physical_node
             distribution="no_distribution"
 


### PR DESCRIPTION
- Only set up cached nodes when inside a flux allocation
- Only echo cached nodes when verbose is set
- Echo physical node for a test when same_node and verbose are both set