### PR TITLE
exception handling for cpx mode

### DIFF
--- a/ats/atsMachines/fluxScheduled.py
+++ b/ats/atsMachines/fluxScheduled.py
@@ -632,6 +632,8 @@ class FluxScheduled(lcMachines.LCMachineCore):
             # Handle the case where the command fails
             print(f"INFO: rocm-smi failed with error: {e}")
             found_cpx = False
+        except FileNotFoundError:
+            found_cpx = False
 
         return found_cpx
 


### PR DESCRIPTION
This can happen on CTS 2 machines using flux.